### PR TITLE
55 withdraw api

### DIFF
--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -4,6 +4,7 @@ import strategiesRoutes from './strategies/strategiesRoutes'
 import operatorRoutes from './operators/operatorRoutes'
 import stakerRoutes from './stakers/stakerRoutes'
 import metricRoutes from './metrics/metricRoutes'
+import withdrawalRoutes from './withdrawals/withdrawalRoutes'
 
 const apiRouter = express.Router()
 
@@ -12,5 +13,6 @@ apiRouter.use('/strategies', strategiesRoutes)
 apiRouter.use('/operators', operatorRoutes)
 apiRouter.use('/stakers', stakerRoutes)
 apiRouter.use('/metrics', metricRoutes)
+apiRouter.use('/withdrawals', withdrawalRoutes)
 
 export default apiRouter

--- a/packages/api/src/routes/stakers/stakerController.ts
+++ b/packages/api/src/routes/stakers/stakerController.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from 'express'
 import prisma from '../../utils/prismaClient'
 import { handleAndReturnErrorResponse } from '../../schema/errors'
 import { PaginationQuerySchema } from '../../schema/zod/schemas/paginationQuery'
+import { getViemClient } from '../../viem/viemClient'
 
 /**
  * Route to get a list of all stakers
@@ -79,6 +80,233 @@ export async function getStaker(req: Request, res: Response) {
 		res.send({
 			...staker,
 			tvl
+		})
+	} catch (error) {
+		handleAndReturnErrorResponse(req, res, error)
+	}
+}
+
+export async function getStakerWithdrawals(req: Request, res: Response) {
+	// Validate query
+	const result = PaginationQuerySchema.safeParse(req.query)
+	if (!result.success) {
+		return handleAndReturnErrorResponse(req, res, result.error)
+	}
+
+	const { skip, take } = result.data
+
+	try {
+		const { address } = req.params
+		const filterQuery = { stakerAddress: address }
+
+		const withdrawalCount = await prisma.withdrawal.count({
+			where: filterQuery
+		})
+		const withdrawalRecords = await prisma.withdrawal.findMany({
+			where: filterQuery,
+			skip,
+			take,
+			orderBy: { startBlock: 'desc' }
+		})
+
+		const data = withdrawalRecords.map((withdrawal) => {
+			const shares = withdrawal.shares.map((s, i) => ({
+				strategyAddress: withdrawal.strategies[i],
+				shares: s
+			}))
+
+			return {
+				...withdrawal,
+				shares,
+				strategies: undefined,
+				startBlock: Number(withdrawal.startBlock),
+				createdAtBlock: Number(withdrawal.createdAtBlock),
+				updatedAtBlock: Number(withdrawal.updatedAtBlock)
+			}
+		})
+
+		res.send({
+			data,
+			meta: {
+				total: withdrawalCount,
+				skip,
+				take
+			}
+		})
+	} catch (error) {
+		handleAndReturnErrorResponse(req, res, error)
+	}
+}
+
+export async function getStakerWithdrawalsQueued(req: Request, res: Response) {
+	// Validate query
+	const result = PaginationQuerySchema.safeParse(req.query)
+	if (!result.success) {
+		return handleAndReturnErrorResponse(req, res, result.error)
+	}
+
+	const { skip, take } = result.data
+
+	try {
+		const { address } = req.params
+		const filterQuery = { stakerAddress: address, isCompleted: false }
+
+		const withdrawalCount = await prisma.withdrawal.count({
+			where: filterQuery
+		})
+		const withdrawalRecords = await prisma.withdrawal.findMany({
+			where: filterQuery,
+			skip,
+			take,
+			orderBy: { startBlock: 'desc' }
+		})
+
+		const data = withdrawalRecords.map((withdrawal) => {
+			const shares = withdrawal.shares.map((s, i) => ({
+				strategyAddress: withdrawal.strategies[i],
+				shares: s
+			}))
+
+			return {
+				...withdrawal,
+				shares,
+				strategies: undefined,
+				startBlock: Number(withdrawal.startBlock),
+				createdAtBlock: Number(withdrawal.createdAtBlock),
+				updatedAtBlock: Number(withdrawal.updatedAtBlock)
+			}
+		})
+
+		res.send({
+			data,
+			meta: {
+				total: withdrawalCount,
+				skip,
+				take
+			}
+		})
+	} catch (error) {
+		handleAndReturnErrorResponse(req, res, error)
+	}
+}
+
+export async function getStakerWithdrawalsWithdrawable(
+	req: Request,
+	res: Response
+) {
+	// Validate query
+	const result = PaginationQuerySchema.safeParse(req.query)
+	if (!result.success) {
+		return handleAndReturnErrorResponse(req, res, result.error)
+	}
+
+	const { skip, take } = result.data
+
+	try {
+		const { address } = req.params
+
+		const viemClient = getViemClient()
+		const minDelayBlocks = await prisma.settings.findUnique({
+			where: { key: 'withdrawMinDelayBlocks' }
+		})
+		const minDelayBlock =
+			(await viemClient.getBlockNumber()) -
+			BigInt((minDelayBlocks?.value as string) || 0)
+
+		const filterQuery = {
+			stakerAddress: address,
+			isCompleted: false,
+			startBlock: { lte: minDelayBlock }
+		}
+
+		const withdrawalCount = await prisma.withdrawal.count({
+			where: filterQuery
+		})
+		const withdrawalRecords = await prisma.withdrawal.findMany({
+			where: filterQuery,
+			skip,
+			take,
+			orderBy: { startBlock: 'desc' }
+		})
+
+		const data = withdrawalRecords.map((withdrawal) => {
+			const shares = withdrawal.shares.map((s, i) => ({
+				strategyAddress: withdrawal.strategies[i],
+				shares: s
+			}))
+
+			return {
+				...withdrawal,
+				shares,
+				strategies: undefined,
+				startBlock: Number(withdrawal.startBlock),
+				createdAtBlock: Number(withdrawal.createdAtBlock),
+				updatedAtBlock: Number(withdrawal.updatedAtBlock)
+			}
+		})
+
+		res.send({
+			data,
+			meta: {
+				total: withdrawalCount,
+				skip,
+				take
+			}
+		})
+	} catch (error) {
+		handleAndReturnErrorResponse(req, res, error)
+	}
+}
+
+export async function getStakerWithdrawalsCompleted(
+	req: Request,
+	res: Response
+) {
+	// Validate query
+	const result = PaginationQuerySchema.safeParse(req.query)
+	if (!result.success) {
+		return handleAndReturnErrorResponse(req, res, result.error)
+	}
+
+	const { skip, take } = result.data
+
+	try {
+		const { address } = req.params
+		const filterQuery = { stakerAddress: address, isCompleted: true }
+
+		const withdrawalCount = await prisma.withdrawal.count({
+			where: filterQuery
+		})
+		const withdrawalRecords = await prisma.withdrawal.findMany({
+			where: filterQuery,
+			skip,
+			take,
+			orderBy: { startBlock: 'desc' }
+		})
+
+		const data = withdrawalRecords.map((withdrawal) => {
+			const shares = withdrawal.shares.map((s, i) => ({
+				strategyAddress: withdrawal.strategies[i],
+				shares: s
+			}))
+
+			return {
+				...withdrawal,
+				shares,
+				strategies: undefined,
+				startBlock: Number(withdrawal.startBlock),
+				createdAtBlock: Number(withdrawal.createdAtBlock),
+				updatedAtBlock: Number(withdrawal.updatedAtBlock)
+			}
+		})
+
+		res.send({
+			data,
+			meta: {
+				total: withdrawalCount,
+				skip,
+				take
+			}
 		})
 	} catch (error) {
 		handleAndReturnErrorResponse(req, res, error)

--- a/packages/api/src/routes/stakers/stakerRoutes.ts
+++ b/packages/api/src/routes/stakers/stakerRoutes.ts
@@ -1,10 +1,25 @@
 import express from 'express'
-import { getAllStakers, getStaker } from './stakerController'
+import {
+	getAllStakers,
+	getStaker,
+	getStakerWithdrawals,
+	getStakerWithdrawalsCompleted,
+	getStakerWithdrawalsQueued,
+	getStakerWithdrawalsWithdrawable
+} from './stakerController'
 
 const router = express.Router()
 
 router.get('/', getAllStakers)
 
 router.get('/:id', getStaker)
+
+router.get('/:address/withdrawals', getStakerWithdrawals)
+router.get('/:address/withdrawals/queued', getStakerWithdrawalsQueued)
+router.get(
+	'/:address/withdrawals/queued_withdrawable',
+	getStakerWithdrawalsWithdrawable
+)
+router.get('/:address/withdrawals/completed', getStakerWithdrawalsCompleted)
 
 export default router

--- a/packages/api/src/routes/withdrawals/withdrawalController.ts
+++ b/packages/api/src/routes/withdrawals/withdrawalController.ts
@@ -1,0 +1,133 @@
+import type { Request, Response } from 'express'
+import prisma from '../../utils/prismaClient'
+import { handleAndReturnErrorResponse } from '../../schema/errors'
+import { WithdrawalListQuerySchema } from '../../schema/zod/schemas/withdrawal'
+import { PaginationQuerySchema } from '../../schema/zod/schemas/paginationQuery'
+import { getViemClient } from '../../viem/viemClient'
+
+/**
+ * Route to get a list of all withdrawals
+ *
+ * @param req
+ * @param res
+ */
+export async function getAllWithdrawals(req: Request, res: Response) {
+	// Validate query
+	const result = WithdrawalListQuerySchema.and(PaginationQuerySchema).safeParse(
+		req.query
+	)
+	if (!result.success) {
+		return handleAndReturnErrorResponse(req, res, result.error)
+	}
+
+	const { stakerAddress, delegatedTo, strategyAddress, status, skip, take } =
+		result.data
+
+	try {
+		const filterQuery = {}
+
+		if (stakerAddress) {
+			filterQuery['stakerAddress'] = stakerAddress.toLowerCase()
+		}
+
+		if (delegatedTo) {
+			filterQuery['delegatedTo'] = delegatedTo.toLowerCase()
+		}
+
+		if (strategyAddress) {
+			filterQuery['strategies'] = { has: strategyAddress.toLowerCase() }
+		}
+
+		if (status) {
+			switch (status) {
+				case 'queued':
+					filterQuery['isCompleted'] = false
+					break
+				case 'queued_withdrawable':
+					const viemClient = getViemClient()
+					const minDelayBlocks = await prisma.settings.findUnique({
+						where: { key: 'withdrawMinDelayBlocks' }
+					})
+					const minDelayBlock =
+						(await viemClient.getBlockNumber()) -
+						BigInt((minDelayBlocks?.value as string) || 0)
+
+					filterQuery['isCompleted'] = false
+					filterQuery['startBlock'] = { lte: minDelayBlock }
+					break
+				case 'completed':
+					filterQuery['isCompleted'] = true
+					break
+			}
+		}
+
+		const withdrawalCount = await prisma.withdrawal.count({
+			where: filterQuery
+		})
+		const withdrawalRecords = await prisma.withdrawal.findMany({
+			where: filterQuery,
+			skip,
+			take,
+			orderBy: { startBlock: 'desc' }
+		})
+
+		const data = withdrawalRecords.map((withdrawal) => {
+			const shares = withdrawal.shares.map((s, i) => ({
+				strategyAddress: withdrawal.strategies[i],
+				shares: s
+			}))
+
+			return {
+				...withdrawal,
+				shares,
+				strategies: undefined,
+				startBlock: Number(withdrawal.startBlock),
+				createdAtBlock: Number(withdrawal.createdAtBlock),
+				updatedAtBlock: Number(withdrawal.updatedAtBlock)
+			}
+		})
+
+		res.send({
+			data,
+			meta: {
+				total: withdrawalCount,
+				skip,
+				take
+			}
+		})
+	} catch (error) {
+		handleAndReturnErrorResponse(req, res, error)
+	}
+}
+
+/**
+ * Route to get a single withdrawal
+ *
+ * @param req
+ * @param res
+ */
+export async function getWithdrawal(req: Request, res: Response) {
+	try {
+		const { withdrawalRoot } = req.params
+
+		const withdrawal = await prisma.withdrawal.findUniqueOrThrow({
+			where: { withdrawalRoot }
+		})
+
+		const shares = withdrawal.shares.map((s, i) => ({
+			strategyAddress: withdrawal.strategies[i],
+			shares: s
+		}))
+
+		res.send({
+			...withdrawal,
+			shares,
+			strategies: undefined,
+			startBlock: Number(withdrawal.startBlock),
+			createdAtBlock: Number(withdrawal.createdAtBlock),
+			updatedAtBlock: Number(withdrawal.updatedAtBlock)
+		})
+	} catch (error) {
+		handleAndReturnErrorResponse(req, res, error)
+	}
+}

--- a/packages/api/src/routes/withdrawals/withdrawalRoutes.ts
+++ b/packages/api/src/routes/withdrawals/withdrawalRoutes.ts
@@ -1,0 +1,10 @@
+import express from 'express'
+import { getAllWithdrawals, getWithdrawal } from './withdrawalController'
+
+const router = express.Router()
+
+router.get('/', getAllWithdrawals)
+
+router.get('/:withdrawalRoot', getWithdrawal)
+
+export default router

--- a/packages/api/src/schema/zod/schemas/withdrawal.ts
+++ b/packages/api/src/schema/zod/schemas/withdrawal.ts
@@ -1,0 +1,20 @@
+import z from '../'
+
+export const WithdrawalListQuerySchema = z.object({
+	stakerAddress: z
+		.string()
+		.regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid Ethereum address')
+		.optional(),
+
+	delegatedTo: z
+		.string()
+		.regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid Ethereum address')
+		.optional(),
+
+	strategyAddress: z
+		.string()
+		.regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid Ethereum address')
+		.optional(),
+
+	status: z.enum(['queued', 'queued_withdrawable', 'completed']).optional()
+})

--- a/packages/prisma/migrations/20240517105109_withdrawal_data/migration.sql
+++ b/packages/prisma/migrations/20240517105109_withdrawal_data/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "Withdrawal" (
+    "withdrawalRoot" TEXT NOT NULL,
+    "nonce" INTEGER NOT NULL,
+    "isCompleted" BOOLEAN NOT NULL DEFAULT false,
+    "stakerAddress" TEXT NOT NULL,
+    "delegatedTo" TEXT NOT NULL,
+    "withdrawerAddress" TEXT NOT NULL,
+    "strategies" TEXT[],
+    "shares" TEXT[],
+    "startBlock" BIGINT NOT NULL,
+    "createdAtBlock" BIGINT NOT NULL,
+    "updatedAtBlock" BIGINT NOT NULL,
+
+    CONSTRAINT "Withdrawal_pkey" PRIMARY KEY ("withdrawalRoot")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Withdrawal_withdrawalRoot_key" ON "Withdrawal"("withdrawalRoot");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -124,6 +124,22 @@ model Validator {
   withdrawalCredentials String
 }
 
+model Withdrawal {
+  withdrawalRoot String  @id @unique
+  nonce          Int
+  isCompleted    Boolean @default(false)
+
+  stakerAddress     String
+  delegatedTo       String
+  withdrawerAddress String
+  strategies        String[]
+  shares            String[]
+  startBlock        BigInt
+
+  createdAtBlock BigInt
+  updatedAtBlock BigInt
+}
+
 // Collection to store system settings
 model Settings {
   key       String   @id @unique

--- a/packages/seeder/src/index.ts
+++ b/packages/seeder/src/index.ts
@@ -8,6 +8,8 @@ import { seedStakers } from './seedStakers'
 import { getViemClient } from './utils/viemClient'
 import { seedOperatorShares } from './seedOperatorShares'
 import { seedValidators } from './seedValidators'
+import { seedQueuedWithdrawals } from './seedWithdrawalsQueued'
+import { seedCompletedWithdrawals } from './seedWithdrawalsCompleted'
 
 console.log('Initializing seeder ...')
 
@@ -27,6 +29,9 @@ async function seedEigenDataLoop() {
 			await seedAvsOperators(targetBlock)
 			await seedStakers(targetBlock)
 			await seedOperatorShares(targetBlock)
+			await seedQueuedWithdrawals(targetBlock)
+			await seedCompletedWithdrawals(targetBlock)
+
 		} catch (error) {
 			console.log('Failed to seed AVS and Opeartors at:', Date.now())
 		}

--- a/packages/seeder/src/index.ts
+++ b/packages/seeder/src/index.ts
@@ -31,7 +31,6 @@ async function seedEigenDataLoop() {
 			await seedOperatorShares(targetBlock)
 			await seedQueuedWithdrawals(targetBlock)
 			await seedCompletedWithdrawals(targetBlock)
-
 		} catch (error) {
 			console.log('Failed to seed AVS and Opeartors at:', Date.now())
 		}

--- a/packages/seeder/src/seedWithdrawalsCompleted.ts
+++ b/packages/seeder/src/seedWithdrawalsCompleted.ts
@@ -16,7 +16,10 @@ const blockSyncKey = 'lastSyncedBlock_completedWithdrawals'
  * @param fromBlock
  * @param toBlock
  */
-export async function seedCompletedWithdrawals(toBlock?: bigint, fromBlock?: bigint) {
+export async function seedCompletedWithdrawals(
+	toBlock?: bigint,
+	fromBlock?: bigint
+) {
 	console.log('Seeding Completed Withdrawals ...')
 
 	const viemClient = getViemClient()
@@ -56,16 +59,16 @@ export async function seedCompletedWithdrawals(toBlock?: bigint, fromBlock?: big
 	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 	const dbTransactions: any[] = []
 
-  if (completedWithdrawalList.length > 0) {
-    dbTransactions.push(
-      prismaClient.withdrawal.updateMany({
-        where: { withdrawalRoot: { in: completedWithdrawalList } },
-        data: {
-          isCompleted: true
-        }
-      })
-    )
-  }
+	if (completedWithdrawalList.length > 0) {
+		dbTransactions.push(
+			prismaClient.withdrawal.updateMany({
+				where: { withdrawalRoot: { in: completedWithdrawalList } },
+				data: {
+					isCompleted: true
+				}
+			})
+		)
+	}
 
 	await bulkUpdateDbTransactions(dbTransactions)
 

--- a/packages/seeder/src/seedWithdrawalsCompleted.ts
+++ b/packages/seeder/src/seedWithdrawalsCompleted.ts
@@ -1,0 +1,76 @@
+import { parseAbiItem } from 'viem'
+import { getEigenContracts } from './data/address'
+import { getViemClient } from './utils/viemClient'
+import { getPrismaClient } from './utils/prismaClient'
+import {
+	bulkUpdateDbTransactions,
+	fetchLastSyncBlock,
+	loopThroughBlocks,
+	saveLastSyncBlock
+} from './utils/seeder'
+
+const blockSyncKey = 'lastSyncedBlock_completedWithdrawals'
+
+/**
+ *
+ * @param fromBlock
+ * @param toBlock
+ */
+export async function seedCompletedWithdrawals(toBlock?: bigint, fromBlock?: bigint) {
+	console.log('Seeding Completed Withdrawals ...')
+
+	const viemClient = getViemClient()
+	const prismaClient = getPrismaClient()
+	const completedWithdrawalList: string[] = []
+
+	const firstBlock = fromBlock
+		? fromBlock
+		: await fetchLastSyncBlock(blockSyncKey)
+	const lastBlock = toBlock ? toBlock : await viemClient.getBlockNumber()
+
+	// Loop through evm logs
+	await loopThroughBlocks(firstBlock, lastBlock, async (fromBlock, toBlock) => {
+		const logs = await viemClient.getLogs({
+			address: getEigenContracts().DelegationManager,
+			event: parseAbiItem('event WithdrawalCompleted(bytes32 withdrawalRoot)'),
+			fromBlock,
+			toBlock
+		})
+
+		for (const l in logs) {
+			const log = logs[l]
+
+			const withdrawalRoot = log.args.withdrawalRoot
+
+			if (withdrawalRoot) {
+				completedWithdrawalList.push(withdrawalRoot)
+			}
+		}
+
+		console.log(
+			`Withdrawals completed between blocks ${fromBlock} ${toBlock}: ${logs.length}`
+		)
+	})
+
+	// Prepare db transaction object
+	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+	const dbTransactions: any[] = []
+
+  if (completedWithdrawalList.length > 0) {
+    dbTransactions.push(
+      prismaClient.withdrawal.updateMany({
+        where: { withdrawalRoot: { in: completedWithdrawalList } },
+        data: {
+          isCompleted: true
+        }
+      })
+    )
+  }
+
+	await bulkUpdateDbTransactions(dbTransactions)
+
+	// // Storing last sycned block
+	await saveLastSyncBlock(blockSyncKey, lastBlock)
+
+	console.log('Seeded Completed Withdrawals:', completedWithdrawalList.length)
+}

--- a/packages/seeder/src/seedWithdrawalsQueued.ts
+++ b/packages/seeder/src/seedWithdrawalsQueued.ts
@@ -1,0 +1,113 @@
+import { parseAbiItem } from 'viem'
+import { getEigenContracts } from './data/address'
+import { getViemClient } from './utils/viemClient'
+import { getPrismaClient } from './utils/prismaClient'
+import {
+	bulkUpdateDbTransactions,
+	fetchLastSyncBlock,
+	loopThroughBlocks,
+	saveLastSyncBlock
+} from './utils/seeder'
+
+const blockSyncKey = 'lastSyncedBlock_queuedWithdrawals'
+
+interface Withdrawal {
+	withdrawalRoot: string
+	nonce: number
+	isCompleted: boolean
+
+	stakerAddress: string
+	delegatedTo: string
+	withdrawerAddress: string
+	strategies: string[]
+	shares: string[]
+	startBlock: number
+
+	createdAtBlock: number
+	updatedAtBlock: number
+}
+
+/**
+ *
+ * @param fromBlock
+ * @param toBlock
+ */
+export async function seedQueuedWithdrawals(toBlock?: bigint, fromBlock?: bigint) {
+	console.log('Seeding Queued Withdrawals ...')
+
+	const viemClient = getViemClient()
+	const prismaClient = getPrismaClient()
+	const queuedWithdrawalList: Withdrawal[] = []
+
+	const firstBlock = fromBlock
+		? fromBlock
+		: await fetchLastSyncBlock(blockSyncKey)
+	const lastBlock = toBlock ? toBlock : await viemClient.getBlockNumber()
+
+	// Loop through evm logs
+	await loopThroughBlocks(firstBlock, lastBlock, async (fromBlock, toBlock) => {
+		const logs = await viemClient.getLogs({
+			address: getEigenContracts().DelegationManager,
+			event: parseAbiItem(
+				[
+          'event WithdrawalQueued(bytes32 withdrawalRoot, Withdrawal withdrawal)', 
+          'struct Withdrawal { address staker; address delegatedTo; address withdrawer; uint256 nonce; uint32 startBlock; address[] strategies; uint256[] shares; }'
+        ]
+			),
+			fromBlock,
+			toBlock
+		})
+
+		for (const l in logs) {
+			const log = logs[l]
+
+			const withdrawalRoot = log.args.withdrawalRoot
+			const withdrawal = log.args.withdrawal
+
+			if (withdrawalRoot && withdrawal) {
+				const stakerAddress = withdrawal.staker.toLowerCase()
+				const delegatedTo = withdrawal.delegatedTo.toLowerCase()
+				const withdrawerAddress = withdrawal.withdrawer.toLowerCase()
+
+				queuedWithdrawalList.push({
+					withdrawalRoot,
+					nonce: Number(withdrawal.nonce),
+					isCompleted: false,
+					stakerAddress,
+					delegatedTo,
+					withdrawerAddress,
+					strategies: withdrawal.strategies.map(s => s.toLowerCase()) as string[],
+					shares: withdrawal.shares.map(s => BigInt(s).toString()),
+					startBlock: withdrawal.startBlock,
+
+					createdAtBlock: Number(log.blockNumber),
+					updatedAtBlock: Number(log.blockNumber)
+				})
+			}
+		}
+
+		console.log(
+			`Withdrawals queued between blocks ${fromBlock} ${toBlock}: ${logs.length}`
+		)
+	})
+
+	// Prepare db transaction object
+	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+	const dbTransactions: any[] = []
+
+	if (queuedWithdrawalList.length > 0) {
+		dbTransactions.push(
+			prismaClient.withdrawal.createMany({
+				data: queuedWithdrawalList,
+				skipDuplicates: true
+			})
+		)
+	}
+
+	await bulkUpdateDbTransactions(dbTransactions)
+
+	// // Storing last sycned block
+	await saveLastSyncBlock(blockSyncKey, lastBlock)
+
+	console.log('Seeded Queued Withdrawals:', queuedWithdrawalList.length)
+}

--- a/packages/seeder/src/seedWithdrawalsQueued.ts
+++ b/packages/seeder/src/seedWithdrawalsQueued.ts
@@ -32,7 +32,10 @@ interface Withdrawal {
  * @param fromBlock
  * @param toBlock
  */
-export async function seedQueuedWithdrawals(toBlock?: bigint, fromBlock?: bigint) {
+export async function seedQueuedWithdrawals(
+	toBlock?: bigint,
+	fromBlock?: bigint
+) {
 	console.log('Seeding Queued Withdrawals ...')
 
 	const viemClient = getViemClient()
@@ -48,12 +51,10 @@ export async function seedQueuedWithdrawals(toBlock?: bigint, fromBlock?: bigint
 	await loopThroughBlocks(firstBlock, lastBlock, async (fromBlock, toBlock) => {
 		const logs = await viemClient.getLogs({
 			address: getEigenContracts().DelegationManager,
-			event: parseAbiItem(
-				[
-          'event WithdrawalQueued(bytes32 withdrawalRoot, Withdrawal withdrawal)', 
-          'struct Withdrawal { address staker; address delegatedTo; address withdrawer; uint256 nonce; uint32 startBlock; address[] strategies; uint256[] shares; }'
-        ]
-			),
+			event: parseAbiItem([
+				'event WithdrawalQueued(bytes32 withdrawalRoot, Withdrawal withdrawal)',
+				'struct Withdrawal { address staker; address delegatedTo; address withdrawer; uint256 nonce; uint32 startBlock; address[] strategies; uint256[] shares; }'
+			]),
 			fromBlock,
 			toBlock
 		})
@@ -76,8 +77,10 @@ export async function seedQueuedWithdrawals(toBlock?: bigint, fromBlock?: bigint
 					stakerAddress,
 					delegatedTo,
 					withdrawerAddress,
-					strategies: withdrawal.strategies.map(s => s.toLowerCase()) as string[],
-					shares: withdrawal.shares.map(s => BigInt(s).toString()),
+					strategies: withdrawal.strategies.map((s) =>
+						s.toLowerCase()
+					) as string[],
+					shares: withdrawal.shares.map((s) => BigInt(s).toString()),
 					startBlock: withdrawal.startBlock,
 
 					createdAtBlock: Number(log.blockNumber),


### PR DESCRIPTION
This PR includes 2 types of routes for withdrawals

[Individual]
```
/withdrawals?{queryparams}
- stakerAddress?: string // Filter by address of the staker
- delegatedTo?: string // Filter by operator delegated to
- strategyAddress: string // Filter by strategy address
- status: 'queued' | 'queued_withdrawable' | 'completed' // Filter by the current status of the deposit
... and the regular pagination query 
```

```
/withdrawals/:withdrawalRoot
- withdrawalRoot: string // The ID of the withdrawal
```

[Nested]
`/stakers/:address/withdrawals` Lists all stakers withdrawals with pagination (all status included)
`/stakers/:address/withdrawals/queued` Lists all stakers withdrawals with pagination (ONLY queued)
`/stakers/:address/withdrawals/queued_withdrawable` Lists all stakers withdrawals with pagination (BOTH queued and queued + waiting for staker to withdraw)
`/api/stakers/:address/withdrawals/completed` Lists all stakers withdrawals with pagination (ONLY completed)