### PR TITLE
Pass CI build version as the API version, displayed in routes

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -41,13 +41,13 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image }}
-      
+
       - name: install modules
         run: npm i
 
@@ -59,3 +59,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            CI_BUILD_VERSION=${{ github.ref_name }}

--- a/Dockerfile-API
+++ b/Dockerfile-API
@@ -2,6 +2,9 @@ FROM node:18
 
 WORKDIR /app
 
+ARG CI_BUILD_VERSION
+ENV API_VERSION=$CI_BUILD_VERSION
+
 COPY ./packages/api/package*.json ./
 
 RUN npm install

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -11,6 +11,11 @@ const apiRouter = express.Router()
 // Health route
 apiRouter.get('/health', (_, res) => res.send({ status: 'ok' }))
 
+// Version route
+apiRouter.get('/version', (_, res) =>
+	res.send({ version: process.env.API_VERSION || 'development' })
+)
+
 // Remaining routes
 apiRouter.use('/avs', avsRoutes)
 apiRouter.use('/strategies', strategiesRoutes)


### PR DESCRIPTION
Example: https://api-dev.eigenexplorer.com/version