### PR TITLE
93 binance wallet getrestakedpointsreward

### DIFF
--- a/packages/api/src/routes/stakers/stakerController.ts
+++ b/packages/api/src/routes/stakers/stakerController.ts
@@ -452,7 +452,6 @@ export async function getRestakedPoints(req: Request, res: Response) {
 		})
 
 		const now = Number(new Date())
-		console.log(depositRecords.length)
 		// Store total ETH ⋅ hours of beacon ETH & each LST strategy from deposit time to current time
 		const depositsSumByToken = {}
 		for (const deposit of depositRecords) {
@@ -474,7 +473,7 @@ export async function getRestakedPoints(req: Request, res: Response) {
 		if (beaconDepositRecords.length > 0) {
 			const firstEpoch = getFirstEpoch()
 			const beaconDepositsSum = beaconDepositRecords.reduce((acc, record) => {
-				const activatedAt = Number(record.activationEpoch) * 384 + firstEpoch
+				const activatedAt = Number(record.activationEpoch) * 384000 + firstEpoch
 				const shares = Number(32)
 				const timeDiff = (now - Number(activatedAt)) / (1000 * 60 * 60)
 				return acc + Number(shares) * Math.round(timeDiff)
@@ -573,5 +572,5 @@ async function getBeaconEthData(address: string) {
 }
 
 function getFirstEpoch() {
-	return getNetwork() === holesky ? 1695902400 : 1606824023
+	return getNetwork() === holesky ? 1695902400000 : 1606824023000
 }

--- a/packages/api/src/routes/stakers/stakerRoutes.ts
+++ b/packages/api/src/routes/stakers/stakerRoutes.ts
@@ -6,7 +6,8 @@ import {
 	getStakerWithdrawalsCompleted,
 	getStakerWithdrawalsQueued,
 	getStakerWithdrawalsWithdrawable,
-	getStakerDeposits
+	getStakerDeposits,
+	getRestakedPoints
 } from './stakerController'
 
 const router = express.Router()
@@ -24,5 +25,7 @@ router.get(
 router.get('/:address/withdrawals/completed', getStakerWithdrawalsCompleted)
 
 router.get('/:address/deposits', getStakerDeposits)
+
+router.get('/:address/restaked-points', getRestakedPoints)
 
 export default router

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -159,6 +159,7 @@ model Validator {
   effectiveBalance      BigInt
   slashed               Boolean
   withdrawalCredentials String
+  activationEpoch       BigInt
 }
 
 model Withdrawal {
@@ -172,6 +173,7 @@ model Withdrawal {
   strategies        String[]
   shares            String[]
   startBlock        BigInt
+  receiveAsTokens   Boolean @default(false)
 
   createdAtBlock BigInt   @default(0)
   updatedAtBlock BigInt   @default(0)
@@ -252,6 +254,22 @@ model EventLogs_PodDeployed {
 
   @@id([transactionHash, transactionIndex])
   @@index([eigenPod, podOwner])
+}
+
+model EventLogs_PodSharesUpdated {
+  address String
+
+  transactionHash  String
+  transactionIndex Int
+  blockNumber      BigInt
+  blockHash        String
+  blockTime        DateTime
+
+  podOwner    String
+  sharesDelta String
+
+  @@id([transactionHash, transactionIndex])
+  @@index([podOwner])
 }
 
 model EventLogs_StakerDelegated {

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -162,10 +162,9 @@ model Validator {
   activationEpoch       BigInt
 }
 
-model Withdrawal {
+model WithdrawalQueued {
   withdrawalRoot String  @id @unique
   nonce          Int
-  isCompleted    Boolean @default(false)
 
   stakerAddress     String
   delegatedTo       String
@@ -173,12 +172,21 @@ model Withdrawal {
   strategies        String[]
   shares            String[]
   startBlock        BigInt
+
+  createdAtBlock BigInt   @default(0)
+  createdAt      DateTime @default(now())
+
+  completedWithdrawal WithdrawalCompleted?
+}
+
+model WithdrawalCompleted {
+  withdrawalRoot    String  @id @unique
   receiveAsTokens   Boolean @default(false)
 
   createdAtBlock BigInt   @default(0)
-  updatedAtBlock BigInt   @default(0)
   createdAt      DateTime @default(now())
-  updatedAt      DateTime @default(now())
+
+  queuedWithdrawal WithdrawalQueued  @relation(fields: [withdrawalRoot], references: [withdrawalRoot])
 }
 
 // Collection to store system settings

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -144,7 +144,9 @@ model Pod {
 model ValidatorRestake {
   podAddress     String
   validatorIndex BigInt
-  blockNumber    BigInt
+
+  createdAtBlock BigInt   @default(0)
+  createdAt      DateTime @default(now())
 
   @@id([podAddress, validatorIndex])
 }
@@ -373,6 +375,21 @@ model EventLogs_Deposit {
 
   @@id([transactionHash, transactionIndex])
   @@index([staker])
+}
+
+model EventLogs_ValidatorRestaked {
+  address String
+
+  transactionHash  String
+  transactionIndex Int
+  blockNumber      BigInt
+  blockHash        String
+  blockTime        DateTime
+
+  validatorIndex   BigInt
+
+  @@id([transactionHash, transactionIndex])
+  @@index([validatorIndex])
 }
 
 // Misc

--- a/packages/seeder/src/events/seedLogsPodSharesUpdated.ts
+++ b/packages/seeder/src/events/seedLogsPodSharesUpdated.ts
@@ -1,0 +1,92 @@
+import prisma from '@prisma/client'
+import { parseAbiItem } from 'viem'
+import { getEigenContracts } from '../data/address'
+import { getViemClient } from '../utils/viemClient'
+import {
+	bulkUpdateDbTransactions,
+	fetchLastSyncBlock,
+	getBlockDataFromDb,
+	loopThroughBlocks
+} from '../utils/seeder'
+import { getPrismaClient } from '../utils/prismaClient'
+
+const blockSyncKeyLogs = 'lastSyncedBlock_logs_podShares'
+
+/**
+ * Utility function to seed event logs
+ *
+ * @param fromBlock
+ * @param toBlock
+ */
+export async function seedLogsPodSharesUpdated(
+	toBlock?: bigint,
+	fromBlock?: bigint
+) {
+	const viemClient = getViemClient()
+	const prismaClient = getPrismaClient()
+
+	const firstBlock = fromBlock
+		? fromBlock
+		: await fetchLastSyncBlock(blockSyncKeyLogs)
+	const lastBlock = toBlock ? toBlock : await viemClient.getBlockNumber()
+
+	// Loop through evm logs
+	await loopThroughBlocks(firstBlock, lastBlock, async (fromBlock, toBlock) => {
+		const blockData = await getBlockDataFromDb(fromBlock, toBlock)
+
+		try {
+			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+			const dbTransactions: any[] = []
+			const logsPodSharesUpdated: prisma.EventLogs_PodSharesUpdated[] = []
+
+			const logs = await viemClient.getLogs({
+				address: getEigenContracts().EigenPodManager,
+				event: parseAbiItem(
+					'event PodSharesUpdated(address indexed podOwner, int256 sharesDelta)'
+				),
+				fromBlock,
+				toBlock
+			})
+
+			// Setup a list containing event data
+			for (const l in logs) {
+				const log = logs[l]
+
+				logsPodSharesUpdated.push({
+					address: log.address,
+					transactionHash: log.transactionHash,
+					transactionIndex: log.logIndex,
+					blockNumber: BigInt(log.blockNumber),
+					blockHash: log.blockHash,
+					blockTime: blockData.get(log.blockNumber) || new Date(0),
+					podOwner: String(log.args.podOwner),
+					sharesDelta: String(log.args.sharesDelta)
+				})
+			}
+
+			dbTransactions.push(
+				prismaClient.eventLogs_PodSharesUpdated.createMany({
+					data: logsPodSharesUpdated,
+					skipDuplicates: true
+				})
+			)
+
+			// Store last synced block
+			dbTransactions.push(
+				prismaClient.settings.upsert({
+					where: { key: blockSyncKeyLogs },
+					update: { value: Number(toBlock) },
+					create: { key: blockSyncKeyLogs, value: Number(toBlock) }
+				})
+			)
+
+			// Update database
+			const seedLength = logsPodSharesUpdated.length
+
+			await bulkUpdateDbTransactions(
+				dbTransactions,
+				`[Logs] Pod Shares Updated from: ${fromBlock} to: ${toBlock} size: ${seedLength}`
+			)
+		} catch (error) {}
+	})
+}

--- a/packages/seeder/src/events/seedLogsValidatorRestaked.ts
+++ b/packages/seeder/src/events/seedLogsValidatorRestaked.ts
@@ -1,0 +1,89 @@
+import prisma from '@prisma/client'
+import { parseAbiItem } from 'viem'
+import { getViemClient } from '../utils/viemClient'
+import {
+	bulkUpdateDbTransactions,
+	fetchLastSyncBlock,
+	getBlockDataFromDb,
+	loopThroughBlocks
+} from '../utils/seeder'
+import { getPrismaClient } from '../utils/prismaClient'
+
+const blockSyncKeyLogs = 'lastSyncedBlock_logs_validatorRestake'
+
+/**
+ * Utility function to seed event logs
+ *
+ * @param fromBlock
+ * @param toBlock
+ */
+export async function seedLogsValidatorRestaked(
+	toBlock?: bigint,
+	fromBlock?: bigint
+) {
+	const viemClient = getViemClient()
+	const prismaClient = getPrismaClient()
+
+	const firstBlock = fromBlock
+		? fromBlock
+		: await fetchLastSyncBlock(blockSyncKeyLogs)
+	const lastBlock = toBlock ? toBlock : await viemClient.getBlockNumber()
+
+	// Loop through evm logs
+	await loopThroughBlocks(firstBlock, lastBlock, async (fromBlock, toBlock) => {
+		const blockData = await getBlockDataFromDb(fromBlock, toBlock)
+
+		try {
+			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+			const dbTransactions: any[] = []
+			const logsValidatorRestaked: prisma.EventLogs_ValidatorRestaked[] = []
+
+			const logs = await viemClient.getLogs({
+				event: parseAbiItem('event ValidatorRestaked(uint40 validatorIndex)'),
+				fromBlock,
+				toBlock
+			})
+
+			// Setup a list containing event data
+			for (const l in logs) {
+				const log = logs[l]
+
+				if (log.args.validatorIndex) {
+					logsValidatorRestaked.push({
+						address: log.address,
+						transactionHash: log.transactionHash,
+						transactionIndex: log.logIndex,
+						blockNumber: BigInt(log.blockNumber),
+						blockHash: log.blockHash,
+						blockTime: blockData.get(log.blockNumber) || new Date(0),
+						validatorIndex: BigInt(log.args.validatorIndex)
+					})
+				}
+			}
+
+			dbTransactions.push(
+				prismaClient.eventLogs_ValidatorRestaked.createMany({
+					data: logsValidatorRestaked,
+					skipDuplicates: true
+				})
+			)
+
+			// Store last synced block
+			dbTransactions.push(
+				prismaClient.settings.upsert({
+					where: { key: blockSyncKeyLogs },
+					update: { value: Number(toBlock) },
+					create: { key: blockSyncKeyLogs, value: Number(toBlock) }
+				})
+			)
+
+			// Update database
+			const seedLength = logsValidatorRestaked.length
+
+			await bulkUpdateDbTransactions(
+				dbTransactions,
+				`[Logs] Validator Restake from: ${fromBlock} to: ${toBlock} size: ${seedLength}`
+			)
+		} catch (error) {}
+	})
+}

--- a/packages/seeder/src/index.ts
+++ b/packages/seeder/src/index.ts
@@ -24,7 +24,7 @@ import { seedDeposits } from './seedDeposits'
 import { monitorAvsMetadata } from './monitors/avsMetadata'
 import { monitorOperatorMetadata } from './monitors/operatorMetadata'
 import { seedLogsValidatorRestaked } from './events/seedLogsValidatorRestaked'
-import { seedValidatorRestake } from './seedValidatorRestake'
+import { seedValidatorsRestake } from './seedValidatorsRestake'
 
 console.log('Initializing Seeder ...')
 

--- a/packages/seeder/src/index.ts
+++ b/packages/seeder/src/index.ts
@@ -23,6 +23,8 @@ import { seedLogsDeposit } from './events/seedLogsDeposit'
 import { seedDeposits } from './seedDeposits'
 import { monitorAvsMetadata } from './monitors/avsMetadata'
 import { monitorOperatorMetadata } from './monitors/operatorMetadata'
+import { seedLogsValidatorRestaked } from './events/seedLogsValidatorRestaked'
+import { seedValidatorsRestake } from './seedValidatorsRestake'
 
 console.log('Initializing Seeder ...')
 
@@ -47,6 +49,7 @@ async function seedEigenDataLoop() {
 			await seedLogsWithdrawalQueued(targetBlock)
 			await seedLogsWithdrawalCompleted(targetBlock)
 			await seedLogsDeposit(targetBlock)
+			await seedLogsValidatorRestaked(targetBlock)
 
 			await seedAvs()
 			await seedOperators()
@@ -91,6 +94,7 @@ async function seedEigenPodValidators() {
 			console.log('\nSeeding Eigen Pods data ...')
 
 			await seedValidators()
+			await seedValidatorsRestake()
 		} catch (error) {
 			console.log(error)
 			console.log('Failed to seed Validators at:', Date.now())

--- a/packages/seeder/src/index.ts
+++ b/packages/seeder/src/index.ts
@@ -24,7 +24,7 @@ import { seedDeposits } from './seedDeposits'
 import { monitorAvsMetadata } from './monitors/avsMetadata'
 import { monitorOperatorMetadata } from './monitors/operatorMetadata'
 import { seedLogsValidatorRestaked } from './events/seedLogsValidatorRestaked'
-import { seedValidatorsRestake } from './seedValidatorsRestake'
+import { seedValidatorRestake } from './seedValidatorRestake'
 
 console.log('Initializing Seeder ...')
 
@@ -94,7 +94,7 @@ async function seedEigenPodValidators() {
 			console.log('\nSeeding Eigen Pods data ...')
 
 			await seedValidators()
-			await seedValidatorsRestake()
+			await seedValidatorRestake()
 		} catch (error) {
 			console.log(error)
 			console.log('Failed to seed Validators at:', Date.now())

--- a/packages/seeder/src/index.ts
+++ b/packages/seeder/src/index.ts
@@ -94,7 +94,7 @@ async function seedEigenPodValidators() {
 			console.log('\nSeeding Eigen Pods data ...')
 
 			await seedValidators()
-			await seedValidatorRestake()
+			await seedValidatorsRestake()
 		} catch (error) {
 			console.log(error)
 			console.log('Failed to seed Validators at:', Date.now())

--- a/packages/seeder/src/index.ts
+++ b/packages/seeder/src/index.ts
@@ -23,8 +23,7 @@ import { seedLogsDeposit } from './events/seedLogsDeposit'
 import { seedDeposits } from './seedDeposits'
 import { monitorAvsMetadata } from './monitors/avsMetadata'
 import { monitorOperatorMetadata } from './monitors/operatorMetadata'
-import { seedLogsValidatorRestaked } from './events/seedLogsValidatorRestaked'
-import { seedValidatorsRestake } from './seedValidatorsRestake'
+import { seedLogsPodSharesUpdated } from './events/seedLogsPodSharesUpdated'
 
 console.log('Initializing Seeder ...')
 
@@ -49,7 +48,7 @@ async function seedEigenDataLoop() {
 			await seedLogsWithdrawalQueued(targetBlock)
 			await seedLogsWithdrawalCompleted(targetBlock)
 			await seedLogsDeposit(targetBlock)
-			await seedLogsValidatorRestaked(targetBlock)
+			await seedLogsPodSharesUpdated(targetBlock)
 
 			await seedAvs()
 			await seedOperators()
@@ -94,7 +93,6 @@ async function seedEigenPodValidators() {
 			console.log('\nSeeding Eigen Pods data ...')
 
 			await seedValidators()
-			await seedValidatorsRestake()
 		} catch (error) {
 			console.log(error)
 			console.log('Failed to seed Validators at:', Date.now())
@@ -103,7 +101,6 @@ async function seedEigenPodValidators() {
 		await delay(3600)
 	}
 }
-
 seedEigenDataLoop()
 monitorMetadata()
 seedEigenPodValidators()

--- a/packages/seeder/src/seedValidatorRestake.ts
+++ b/packages/seeder/src/seedValidatorRestake.ts
@@ -1,17 +1,16 @@
 import prisma from '@prisma/client'
 import { getPrismaClient } from './utils/prismaClient'
 import {
-	baseBlock,
 	bulkUpdateDbTransactions,
 	fetchLastSyncBlock,
 	loopThroughBlocks,
 	saveLastSyncBlock
 } from './utils/seeder'
 
-const blockSyncKey = 'lastSyncedBlock_validatorsRestake'
+const blockSyncKey = 'lastSyncedBlock_validatorRestake'
 const blockSyncKeyLogs = 'lastSyncedBlock_logs_validatorRestake'
 
-export async function seedValidatorsRestake(
+export async function seedValidatorRestake(
 	toBlock?: bigint,
 	fromBlock?: bigint
 ) {
@@ -74,10 +73,7 @@ export async function seedValidatorsRestake(
 		)
 	}
 
-	await bulkUpdateDbTransactions(
-		dbTransactions,
-		`[Data] Validator Restake from: ${firstBlock} to: ${lastBlock} size: ${validatorRestakeList.length}`
-	)
+	await bulkUpdateDbTransactions(dbTransactions, `[Data] Validator Restake from: ${firstBlock} to: ${lastBlock} size: ${validatorRestakeList.length}`)
 
 	// Storing last synced block
 	await saveLastSyncBlock(blockSyncKey, lastBlock)

--- a/packages/seeder/src/seedValidators.ts
+++ b/packages/seeder/src/seedValidators.ts
@@ -35,7 +35,7 @@ export async function seedValidators(shouldClearPrev?: boolean) {
 			: 0
 	const chunkSize = 8000
 	const batchSize = 120_000
-	const clearPerv = shouldClearPrev
+	const clearPrev = shouldClearPrev
 		? shouldClearPrev
 		: lastValidatorIndex?.validatorIndex
 		  ? false
@@ -80,7 +80,8 @@ export async function seedValidators(shouldClearPrev?: boolean) {
 							effectiveBalance: v.validator.effective_balance as bigint,
 							slashed: v.validator.slashed as boolean,
 							withdrawalCredentials: v.validator
-								.withdrawal_credentials as string
+								.withdrawal_credentials as string,
+							activationEpoch: v.validator.activation_epoch as bigint
 						})
 					}
 				})
@@ -99,7 +100,7 @@ export async function seedValidators(shouldClearPrev?: boolean) {
 	const dbTransactions: any[] = []
 
 	// Clear all validator data
-	if (clearPerv) {
+	if (clearPrev) {
 		dbTransactions.push(prismaClient.validator.deleteMany())
 	}
 

--- a/packages/seeder/src/seedValidatorsRestake.ts
+++ b/packages/seeder/src/seedValidatorsRestake.ts
@@ -7,10 +7,10 @@ import {
 	saveLastSyncBlock
 } from './utils/seeder'
 
-const blockSyncKey = 'lastSyncedBlock_validatorRestake'
-const blockSyncKeyLogs = 'lastSyncedBlock_logs_validatorRestake'
+const blockSyncKey = 'lastSyncedBlock_validatorsRestake'
+const blockSyncKeyLogs = 'lastSyncedBlock_logs_validatorsRestake'
 
-export async function seedValidatorRestake(
+export async function seedValidatorsRestake(
 	toBlock?: bigint,
 	fromBlock?: bigint
 ) {

--- a/packages/seeder/src/seedWithdrawalsCompleted.ts
+++ b/packages/seeder/src/seedWithdrawalsCompleted.ts
@@ -117,7 +117,8 @@ export async function seedCompletedWithdrawals(
 	if (completedWithdrawalList.length > 0) {
 		dbTransactions.push(
 			prismaClient.withdrawalCompleted.createMany({
-				data: completedWithdrawalList
+				data: completedWithdrawalList,
+				skipDuplicates: true
 			})
 		)
 	}

--- a/packages/seeder/src/seedWithdrawalsQueued.ts
+++ b/packages/seeder/src/seedWithdrawalsQueued.ts
@@ -20,7 +20,7 @@ export async function seedQueuedWithdrawals(
 	fromBlock?: bigint
 ) {
 	const prismaClient = getPrismaClient()
-	const queuedWithdrawalList: prisma.Withdrawal[] = []
+	const queuedWithdrawalList: prisma.WithdrawalQueued[] = []
 
 	const firstBlock = fromBlock
 		? fromBlock
@@ -66,19 +66,15 @@ export async function seedQueuedWithdrawals(
 					queuedWithdrawalList.push({
 						withdrawalRoot,
 						nonce: Number(log.nonce),
-						isCompleted: false,
 						stakerAddress,
 						delegatedTo,
 						withdrawerAddress,
 						strategies: log.strategies.map((s) => s.toLowerCase()) as string[],
 						shares: log.shares.map((s) => s.toString()),
-						receiveAsTokens: false,
 
 						startBlock: log.startBlock,
 						createdAtBlock: blockNumber,
-						updatedAtBlock: blockNumber,
-						createdAt: timestamp,
-						updatedAt: timestamp
+						createdAt: timestamp
 					})
 				}
 			}
@@ -92,7 +88,7 @@ export async function seedQueuedWithdrawals(
 
 	if (queuedWithdrawalList.length > 0) {
 		dbTransactions.push(
-			prismaClient.withdrawal.createMany({
+			prismaClient.withdrawalQueued.createMany({
 				data: queuedWithdrawalList,
 				skipDuplicates: true
 			})

--- a/packages/seeder/src/seedWithdrawalsQueued.ts
+++ b/packages/seeder/src/seedWithdrawalsQueued.ts
@@ -72,6 +72,7 @@ export async function seedQueuedWithdrawals(
 						withdrawerAddress,
 						strategies: log.strategies.map((s) => s.toLowerCase()) as string[],
 						shares: log.shares.map((s) => s.toString()),
+						receiveAsTokens: false,
 
 						startBlock: log.startBlock,
 						createdAtBlock: blockNumber,

--- a/packages/seeder/src/utils/seeder.ts
+++ b/packages/seeder/src/utils/seeder.ts
@@ -28,7 +28,7 @@ export async function loopThroughBlocks(
 
 		await cb(currentBlock, nextBlock)
 
-		currentBlock = nextBlock + 1n
+		currentBlock = nextBlock
 	}
 
 	return lastBlock


### PR DESCRIPTION
A new route `/stakers/:address/restaked-points` that returns participation measure for each token along with total participation measure of the staker. Ref: [EigenLayer Docs: Restaked Points](https://docs.eigenlayer.xyz/eigenlayer/restaking-guides/restaking-user-guide/restaked-points)

## Tests
### 1. Example LSTs
```
GET /stakers/0x5d47e5d242a8f66a6286b0a2353868875f5d6068/restaked-points

{
    "stakerAddress": "0x5d47e5d242a8f66a6286b0a2353868875f5d6068",
    "restakedPoints": [
        {
            "tokenAddress": "0x3f1c547b21f65e10480de3ad8e19faac46c95034",
            "participationMeasure": "204.1345278208596"
        },
        {
            "tokenAddress": "0x94373a4919b3240d86ea41593d5eba789fef3848",
            "participationMeasure": "240607.09999999998"
        },
        {
            "tokenAddress": "0xa63f56985f9c7f3bc9ffc5685535649e0c1a55f3",
            "participationMeasure": "62459.467448092124"
        }
    ],
    "totalParticipationMeasure": "303270.70197591296"
}
```
#### Manual check from DB

```
Token: 0x3f1c547b21f65e10480de3ad8e19faac46c95034
Computation:
(600395670061351922 / 1e18 * (now - 2024-03-26 09:59:00)) - (600395670061352000 / 1e18 * (now - 2024-04-09 14:04:36))
Result: 204.13

Token: 0x94373a4919b3240d86ea41593d5eba789fef3848
Computation:
(100000000000000000 / 1e18 * (now - 2024-03-26 10:31:24)) + (111000000000000000000 / 1e18 * (now -  2024-03-26 20:34:12)) + (100000000000000000 / 1e18 * (now -  2024-03-26 20:35:48)) + (111100000000000000000 / 1e18 * (now -  2024-03-27 15:42:36)) + (111100000000000000000 / 1e18 * (now -  2024-03-28 00:03:48)) - (111100000000000000000 / 1e18 * (now - 2024-04-09 13:42:00)) - (111100000000000000000 / 1e18 * ( now - 2024-03-27 20:33:48))
Result: 240607.1

Token: 0xa63f56985f9c7f3bc9ffc5685535649e0c1a55f3
Computation:
(8787298774061575837  / 1e18 * (now - 2024-03-26 20:58:00)) + (14938407915904678923  / 1e18 * (now - 2024-03-26 21:02:12)) + (24604436567372412344  / 1e18 * (now - 2024-03-26 21:30:24)) + (28998085954403200262  / 1e18 * (now - 2024-03-27 21:30:12)) + (7029839019240000000  / 1e18 * (now - 2024-03-28 18:23:00)) + (7029839019258521338  / 1e18 * (now - 2024-04-03 18:53:36)) + (11387907250240388704  / 1e18 * (now - 2024-04-09 14:08:36)) - (80000000000000000000 / 1e18 * (now - 2024-04-09 13:34:12))
Result: 62459.47

Total: 303270.7
```

### 2. Example Beacon ETH
```
GET /stakers/0xba883657b6dc78046e7bace034a0a049e57b23b3/restaked-points

{
    "stakerAddress": "0xba883657b6dc78046e7bace034a0a049e57b23b3",
    "restakedPoints": [
        {
            "tokenAddress": "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0",
            "participationMeasure": "1472"
        }
    ],
    "totalParticipationMeasure": "1472"
}
```
#### Manual check from DB

```
Token: 0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0
Computation:
(32 * (now - 2024-03-27 07:01:48)) - (32 * (now - 2024-03-29 04:41:00))
Result: 1472
```

## Known issues
When tracking beacon ETH, there seems to be a few cases with 1 more withdrawal than deposits causing a negative `participationMeasure`. Seen for: `0x9893644ef33b252c275fe371846f3e7ee6277172`, `0x7a5f059b59e3698bda318fbb5d9c4838f23eaae6`