### PR TITLE
added route to get 7d and 31d ma eth staking apr

### DIFF
--- a/packages/api/src/routes/metrics/metricController.ts
+++ b/packages/api/src/routes/metrics/metricController.ts
@@ -204,6 +204,26 @@ export async function getHistoricalStakerCount(req: Request, res: Response) {
 	}
 }
 
+export async function getEthStats(req: Request, res: Response) {
+	try {
+		const apiUrl = 'https://beaconcha.in/api/v1/ethstore/latest'
+		const response = await fetch(apiUrl)
+
+		if (!response.ok) {
+			throw new Error(`HTTP error: ${response.status}`)
+		}
+
+		const payload = await response.json()
+
+		res.json({
+			ethApr7d: payload.data.avgapr7d,
+			ethApr31d: payload.data.avgapr31d
+		})
+	} catch (error) {
+		handleAndReturnErrorResponse(req, res, error)
+	}
+}
+
 // ================================================
 
 async function doGetTvl() {

--- a/packages/api/src/routes/metrics/metricRoutes.ts
+++ b/packages/api/src/routes/metrics/metricRoutes.ts
@@ -10,7 +10,8 @@ import {
 	getTvlRestakingByStrategy,
 	getHistoricalAvsCount,
 	getHistoricalOperatorCount,
-	getHistoricalStakerCount
+	getHistoricalStakerCount,
+	getEthStats
 } from './metricController'
 
 import routeCache from 'route-cache'
@@ -56,5 +57,7 @@ router.get(
 	routeCache.cacheSeconds(120),
 	getHistoricalStakerCount
 )
+
+router.get('/eth-stats', routeCache.cacheSeconds(3600), getEthStats)
 
 export default router


### PR DESCRIPTION
Uses `https://beaconcha.in/api/v1/ethstore/latest` with a 1h cache (API is free to use upto 30k requests/mo)

```
GET /metrics//eth-stats

{
    "ethApr7d": 0.034595167868795344,
    "ethApr31d": 0.033450654747796
}

```