### PR TITLE
113 total historic routes deposit withdraw

### DIFF
--- a/packages/api/src/routes/metrics/metricController.ts
+++ b/packages/api/src/routes/metrics/metricController.ts
@@ -141,6 +141,28 @@ export async function getTotalStakers(req: Request, res: Response) {
 	}
 }
 
+export async function getTotalWithdrawals(req: Request, res: Response) {
+	try {
+		const totalWithdrawals = await doGetTotalWithdrawals()
+
+		res.send(totalWithdrawals)
+	} catch (error) {
+		handleAndReturnErrorResponse(req, res, error)
+	}
+}
+
+export async function getTotalDeposits(req: Request, res: Response) {
+	try {
+		const totalDeposits = await doGetTotalDeposits()
+
+		res.send({
+			totalDeposits
+		})
+	} catch (error) {
+		handleAndReturnErrorResponse(req, res, error)
+	}
+}
+
 export async function getHistoricalAvsCount(req: Request, res: Response) {
 	const paramCheck = HistoricalCountSchema.safeParse(req.query)
 	if (!paramCheck.success) {
@@ -331,6 +353,24 @@ async function doGetTotalStakerCount() {
 	})
 
 	return stakers
+}
+
+async function doGetTotalWithdrawals() {
+	const totalWithdrawals = await prisma.withdrawalQueued.count()
+	const completed = await prisma.withdrawalCompleted.count()
+	const pending = totalWithdrawals - completed
+
+	return {
+		totalWithdrawals,
+		pending,
+		completed
+	}
+}
+
+async function doGetTotalDeposits() {
+	const deposits = await prisma.deposit.count()
+
+	return deposits
 }
 
 async function doGetHistoricalCount(

--- a/packages/api/src/routes/metrics/metricController.ts
+++ b/packages/api/src/routes/metrics/metricController.ts
@@ -107,10 +107,10 @@ export async function getTvlRestakingByStrategy(req: Request, res: Response) {
 
 export async function getTotalAvs(req: Request, res: Response) {
 	try {
-		const totalAvs = await doGetTotalAvsCount()
+		const total = await doGetTotalAvsCount()
 
 		res.send({
-			totalAvs
+			total
 		})
 	} catch (error) {
 		handleAndReturnErrorResponse(req, res, error)
@@ -119,10 +119,10 @@ export async function getTotalAvs(req: Request, res: Response) {
 
 export async function getTotalOperators(req: Request, res: Response) {
 	try {
-		const totalOperators = await doGetTotalOperatorCount()
+		const total = await doGetTotalOperatorCount()
 
 		res.send({
-			totalOperators
+			total
 		})
 	} catch (error) {
 		handleAndReturnErrorResponse(req, res, error)
@@ -131,10 +131,10 @@ export async function getTotalOperators(req: Request, res: Response) {
 
 export async function getTotalStakers(req: Request, res: Response) {
 	try {
-		const totalStakers = await doGetTotalStakerCount()
+		const total = await doGetTotalStakerCount()
 
 		res.send({
-			totalStakers
+			total
 		})
 	} catch (error) {
 		handleAndReturnErrorResponse(req, res, error)
@@ -143,9 +143,9 @@ export async function getTotalStakers(req: Request, res: Response) {
 
 export async function getTotalWithdrawals(req: Request, res: Response) {
 	try {
-		const totalWithdrawals = await doGetTotalWithdrawals()
+		const total = await doGetTotalWithdrawals()
 
-		res.send(totalWithdrawals)
+		res.send(total)
 	} catch (error) {
 		handleAndReturnErrorResponse(req, res, error)
 	}
@@ -153,10 +153,10 @@ export async function getTotalWithdrawals(req: Request, res: Response) {
 
 export async function getTotalDeposits(req: Request, res: Response) {
 	try {
-		const totalDeposits = await doGetTotalDeposits()
+		const total = await doGetTotalDeposits()
 
 		res.send({
-			totalDeposits
+			total
 		})
 	} catch (error) {
 		handleAndReturnErrorResponse(req, res, error)
@@ -398,12 +398,12 @@ async function doGetTotalStakerCount() {
 }
 
 async function doGetTotalWithdrawals() {
-	const totalWithdrawals = await prisma.withdrawalQueued.count()
+	const total = await prisma.withdrawalQueued.count()
 	const completed = await prisma.withdrawalCompleted.count()
-	const pending = totalWithdrawals - completed
+	const pending = total - completed
 
 	return {
-		totalWithdrawals,
+		total,
 		pending,
 		completed
 	}

--- a/packages/api/src/routes/metrics/metricController.ts
+++ b/packages/api/src/routes/metrics/metricController.ts
@@ -226,6 +226,48 @@ export async function getHistoricalStakerCount(req: Request, res: Response) {
 	}
 }
 
+export async function getHistoricalWithdrawalCount(req: Request, res: Response) {
+	const paramCheck = HistoricalCountSchema.safeParse(req.query)
+	if (!paramCheck.success) {
+		return handleAndReturnErrorResponse(req, res, paramCheck.error)
+	}
+
+	try {
+		const { frequency, variant, startAt, endAt } = paramCheck.data
+		const data = await doGetHistoricalCount(
+			'withdrawalQueued',
+			startAt,
+			endAt,
+			frequency,
+			variant
+		)
+		res.status(200).send({ data })
+	} catch (error) {
+		handleAndReturnErrorResponse(req, res, error)
+	}
+}
+
+export async function getHistoricalDepositCount(req: Request, res: Response) {
+	const paramCheck = HistoricalCountSchema.safeParse(req.query)
+	if (!paramCheck.success) {
+		return handleAndReturnErrorResponse(req, res, paramCheck.error)
+	}
+
+	try {
+		const { frequency, variant, startAt, endAt } = paramCheck.data
+		const data = await doGetHistoricalCount(
+			'deposit',
+			startAt,
+			endAt,
+			frequency,
+			variant
+		)
+		res.status(200).send({ data })
+	} catch (error) {
+		handleAndReturnErrorResponse(req, res, error)
+	}
+}
+
 // ================================================
 
 async function doGetTvl() {
@@ -374,7 +416,7 @@ async function doGetTotalDeposits() {
 }
 
 async function doGetHistoricalCount(
-	modelName: 'avs' | 'operator' | 'staker',
+	modelName: 'avs' | 'operator' | 'staker' | 'withdrawalQueued' | 'deposit',
 	startAt: string,
 	endAt: string,
 	frequency: string,
@@ -388,7 +430,7 @@ async function doGetHistoricalCount(
 	const startDate = resetTime(new Date(startAt))
 	const endDate = resetTime(new Date(endAt))
 
-	if (!['avs', 'operator', 'staker'].includes(modelName)) {
+	if (!['avs', 'operator', 'staker', 'withdrawalQueued', 'deposit'].includes(modelName)) {
 		throw new Error('Invalid model name')
 	}
 

--- a/packages/api/src/routes/metrics/metricRoutes.ts
+++ b/packages/api/src/routes/metrics/metricRoutes.ts
@@ -11,6 +11,8 @@ import {
 	getHistoricalAvsCount,
 	getHistoricalOperatorCount,
 	getHistoricalStakerCount,
+	getHistoricalDepositCount,
+	getHistoricalWithdrawalCount,
 	getTotalWithdrawals,
 	getTotalDeposits
 } from './metricController'
@@ -61,6 +63,18 @@ router.get(
 	'/historical/stakers',
 	routeCache.cacheSeconds(120),
 	getHistoricalStakerCount
+)
+
+router.get(
+	'/historical/withdrawals',
+	routeCache.cacheSeconds(120),
+	getHistoricalWithdrawalCount
+)
+
+router.get(
+	'/historical/deposits',
+	routeCache.cacheSeconds(120),
+	getHistoricalDepositCount
 )
 
 export default router

--- a/packages/api/src/routes/metrics/metricRoutes.ts
+++ b/packages/api/src/routes/metrics/metricRoutes.ts
@@ -10,7 +10,9 @@ import {
 	getTvlRestakingByStrategy,
 	getHistoricalAvsCount,
 	getHistoricalOperatorCount,
-	getHistoricalStakerCount
+	getHistoricalStakerCount,
+	getTotalWithdrawals,
+	getTotalDeposits
 } from './metricController'
 
 import routeCache from 'route-cache'
@@ -38,6 +40,10 @@ router.get('/total-avs', routeCache.cacheSeconds(120), getTotalAvs)
 router.get('/total-operators', routeCache.cacheSeconds(120), getTotalOperators)
 
 router.get('/total-stakers', routeCache.cacheSeconds(120), getTotalStakers)
+
+router.get('/total-withdrawals', routeCache.cacheSeconds(120), getTotalWithdrawals)
+
+router.get('/total-deposits', routeCache.cacheSeconds(120), getTotalDeposits)
 
 router.get(
 	'/historical/avs',


### PR DESCRIPTION
```
GET /metrics/total-withdrawals

{
    "totalWithdrawals": 64917,
    "pending": 13615,
    "completed": 51302
}

```

```
GET /metrics/total-deposits

{
    "totalDeposits": 297382
}
```

```
GET /metrics/historical/withdrawals?frequency=7d&variant=cumulative

{
    "data": [
        {
            "ts": "2023-06-20T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-06-27T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-07-04T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-07-11T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-07-18T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-07-25T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-08-01T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-08-08T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-08-15T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-08-22T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-08-29T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-09-05T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-09-12T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-09-19T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-09-26T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-10-03T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-10-10T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-10-17T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-10-24T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-10-31T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-11-07T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-11-14T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-11-21T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-11-28T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-12-05T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-12-12T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-12-19T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2023-12-26T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2024-01-02T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2024-01-09T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2024-01-16T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2024-01-23T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2024-01-30T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2024-02-06T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2024-02-13T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2024-02-20T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2024-02-27T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2024-03-05T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2024-03-12T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2024-03-19T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2024-03-26T09:00:00.000Z",
            "value": 0
        },
        {
            "ts": "2024-04-02T09:00:00.000Z",
            "value": 3543
        },
        {
            "ts": "2024-04-09T09:00:00.000Z",
            "value": 7349
        },
        {
            "ts": "2024-04-16T09:00:00.000Z",
            "value": 10604
        },
        {
            "ts": "2024-04-23T09:00:00.000Z",
            "value": 21221
        },
        {
            "ts": "2024-04-30T09:00:00.000Z",
            "value": 34129
        },
        {
            "ts": "2024-05-07T09:00:00.000Z",
            "value": 47942
        },
        {
            "ts": "2024-05-14T09:00:00.000Z",
            "value": 53560
        },
        {
            "ts": "2024-05-21T09:00:00.000Z",
            "value": 57130
        },
        {
            "ts": "2024-05-28T09:00:00.000Z",
            "value": 59067
        },
        {
            "ts": "2024-06-04T09:00:00.000Z",
            "value": 60496
        },
        {
            "ts": "2024-06-11T09:00:00.000Z",
            "value": 64440
        },
        {
            "ts": "2024-06-18T09:00:00.000Z",
            "value": 64912
        }
    ]
}
```

```
GET /metrics/historical/deposits?frequency=1d&variant=cumulative

{
    "data": [
        {
            "ts": "2024-05-19T09:00:00.000Z",
            "value": 275732
        },
        {
            "ts": "2024-05-20T09:00:00.000Z",
            "value": 276628
        },
        {
            "ts": "2024-05-21T09:00:00.000Z",
            "value": 277626
        },
        {
            "ts": "2024-05-22T09:00:00.000Z",
            "value": 278793
        },
        {
            "ts": "2024-05-23T09:00:00.000Z",
            "value": 279611
        },
        {
            "ts": "2024-05-24T09:00:00.000Z",
            "value": 280835
        },
        {
            "ts": "2024-05-25T09:00:00.000Z",
            "value": 282537
        },
        {
            "ts": "2024-05-26T09:00:00.000Z",
            "value": 283505
        },
        {
            "ts": "2024-05-27T09:00:00.000Z",
            "value": 283832
        },
        {
            "ts": "2024-05-28T09:00:00.000Z",
            "value": 284267
        },
        {
            "ts": "2024-05-29T09:00:00.000Z",
            "value": 284696
        },
        {
            "ts": "2024-05-30T09:00:00.000Z",
            "value": 285167
        },
        {
            "ts": "2024-05-31T09:00:00.000Z",
            "value": 285761
        },
        {
            "ts": "2024-06-01T09:00:00.000Z",
            "value": 286342
        },
        {
            "ts": "2024-06-02T09:00:00.000Z",
            "value": 286658
        },
        {
            "ts": "2024-06-03T09:00:00.000Z",
            "value": 287060
        },
        {
            "ts": "2024-06-04T09:00:00.000Z",
            "value": 287594
        },
        {
            "ts": "2024-06-05T09:00:00.000Z",
            "value": 287980
        },
        {
            "ts": "2024-06-06T09:00:00.000Z",
            "value": 288400
        },
        {
            "ts": "2024-06-07T09:00:00.000Z",
            "value": 289067
        },
        {
            "ts": "2024-06-08T09:00:00.000Z",
            "value": 290085
        },
        {
            "ts": "2024-06-09T09:00:00.000Z",
            "value": 291009
        },
        {
            "ts": "2024-06-10T09:00:00.000Z",
            "value": 291531
        },
        {
            "ts": "2024-06-11T09:00:00.000Z",
            "value": 291932
        },
        {
            "ts": "2024-06-12T09:00:00.000Z",
            "value": 292336
        },
        {
            "ts": "2024-06-13T09:00:00.000Z",
            "value": 293111
        },
        {
            "ts": "2024-06-14T09:00:00.000Z",
            "value": 294169
        },
        {
            "ts": "2024-06-15T09:00:00.000Z",
            "value": 295426
        },
        {
            "ts": "2024-06-16T09:00:00.000Z",
            "value": 296343
        },
        {
            "ts": "2024-06-17T09:00:00.000Z",
            "value": 296776
        },
        {
            "ts": "2024-06-18T09:00:00.000Z",
            "value": 297367
        },
        {
            "ts": "2024-06-19T09:00:00.000Z",
            "value": 297367
        }
    ]
}
```
