### PR TITLE
added % change field to historical routes

### DIFF
--- a/packages/api/src/routes/metrics/metricController.ts
+++ b/packages/api/src/routes/metrics/metricController.ts
@@ -392,7 +392,7 @@ async function doGetHistoricalCount(
 				firstRun = false
 			} else if (previousValue) {
 				change =
-					Math.round(((value - previousValue) / previousValue) * 1000) / 1000
+					Math.round(((value - previousValue) / previousValue) * 100000) / 100000
 			} else {
 				change = value ? Number.NaN : 0
 			}

--- a/packages/api/src/routes/metrics/metricController.ts
+++ b/packages/api/src/routes/metrics/metricController.ts
@@ -366,7 +366,7 @@ async function doGetHistoricalCount(
 	let tally = initialTally
 	let currentDate = startDate.getTime()
 	let previousValue = 0
-	let change = 0
+	let change = Number.NaN
 	let firstRun = true
 
 	const timeInterval =
@@ -390,7 +390,6 @@ async function doGetHistoricalCount(
 
 			if (firstRun) {
 				firstRun = false
-				change = Number.NaN
 			} else if (previousValue) {
 				change =
 					Math.round(((value - previousValue) / previousValue) * 1000) / 1000
@@ -408,7 +407,6 @@ async function doGetHistoricalCount(
 		} else {
 			if (firstRun) {
 				firstRun = false
-				change = Number.NaN
 			} else if (previousValue) {
 				tally += intervalData.length
 				change =


### PR DESCRIPTION
Notes:
- `change` is expressed in decimals
- `change` for the first retrieved item is always `null`
- `change` when previous value was `0` is `null` unless the current value is also `0`, in which case it is `0`

#### variant = cumulative
```
GET metrics/historical/avs?frequency=7d&variant=cumulative

{
    "data": [
        {
            "ts": "2024-06-17T11:00:00.000Z",
            "value": 23,
            "change": null
        },
        {
            "ts": "2024-06-17T12:00:00.000Z",
            "value": 23,
            "change": 0
        },
        {
            "ts": "2024-06-17T13:00:00.000Z",
            "value": 22,
            "change": -0.04348
        },
        {
            "ts": "2024-06-17T14:00:00.000Z",
            "value": 5,
            "change": -0.77273
        },
        {
            "ts": "2024-06-17T15:00:00.000Z",
            "value": 6,
            "change": 0.2
        },
        {
            "ts": "2024-06-17T16:00:00.000Z",
            "value": 4,
            "change": -0.33333
        },
        {
            "ts": "2024-06-17T17:00:00.000Z",
            "value": 6,
            "change": 0.5
        },
        {
            "ts": "2024-06-17T18:00:00.000Z",
            "value": 0,
            "change": -1
        },
        {
            "ts": "2024-06-17T19:00:00.000Z",
            "value": 4,
            "change": null
        },
        {
            "ts": "2024-06-17T20:00:00.000Z",
            "value": 7,
            "change": 0.75
        },
        {
            "ts": "2024-06-17T21:00:00.000Z",
            "value": 14,
            "change": 1
        },
        {
            "ts": "2024-06-17T22:00:00.000Z",
            "value": 13,
            "change": -0.07143
        },
        {
            "ts": "2024-06-17T23:00:00.000Z",
            "value": 8,
            "change": -0.38462
        },
        {
            "ts": "2024-06-18T00:00:00.000Z",
            "value": 8,
            "change": 0
        },
        {
            "ts": "2024-06-18T01:00:00.000Z",
            "value": 5,
            "change": -0.375
        },
        {
            "ts": "2024-06-18T02:00:00.000Z",
            "value": 2,
            "change": -0.6
        },
        {
            "ts": "2024-06-18T03:00:00.000Z",
            "value": 3,
            "change": 0.5
        },
        {
            "ts": "2024-06-18T04:00:00.000Z",
            "value": 11,
            "change": 2.66667
        },
        {
            "ts": "2024-06-18T05:00:00.000Z",
            "value": 23,
            "change": 1.09091
        },
        {
            "ts": "2024-06-18T06:00:00.000Z",
            "value": 52,
            "change": 1.26087
        },
        {
            "ts": "2024-06-18T07:00:00.000Z",
            "value": 55,
            "change": 0.05769
        },
        {
            "ts": "2024-06-18T08:00:00.000Z",
            "value": 25,
            "change": -0.54545
        },
        {
            "ts": "2024-06-18T09:00:00.000Z",
            "value": 35,
            "change": 0.4
        },
        {
            "ts": "2024-06-18T10:00:00.000Z",
            "value": 20,
            "change": -0.42857
        },
        {
            "ts": "2024-06-18T11:00:00.000Z",
            "value": 17,
            "change": -0.15
        },
        {
            "ts": "2024-06-18T12:00:00.000Z",
            "value": 15,
            "change": -0.11765
        },
        {
            "ts": "2024-06-18T13:00:00.000Z",
            "value": 2,
            "change": -0.86667
        },
        {
            "ts": "2024-06-18T14:00:00.000Z",
            "value": 2,
            "change": 0
        },
        {
            "ts": "2024-06-18T15:00:00.000Z",
            "value": 7,
            "change": 2.5
        },
        {
            "ts": "2024-06-18T16:00:00.000Z",
            "value": 9,
            "change": 0.28571
        },
        {
            "ts": "2024-06-18T17:00:00.000Z",
            "value": 6,
            "change": -0.33333
        },
        {
            "ts": "2024-06-18T18:00:00.000Z",
            "value": 4,
            "change": -0.33333
        },
        {
            "ts": "2024-06-18T19:00:00.000Z",
            "value": 5,
            "change": 0.25
        },
        {
            "ts": "2024-06-18T20:00:00.000Z",
            "value": 9,
            "change": 0.8
        },
        {
            "ts": "2024-06-18T21:00:00.000Z",
            "value": 11,
            "change": 0.22222
        },
        {
            "ts": "2024-06-18T22:00:00.000Z",
            "value": 5,
            "change": -0.54545
        },
        {
            "ts": "2024-06-18T23:00:00.000Z",
            "value": 11,
            "change": 1.2
        },
        {
            "ts": "2024-06-19T00:00:00.000Z",
            "value": 9,
            "change": -0.18182
        },
        {
            "ts": "2024-06-19T01:00:00.000Z",
            "value": 16,
            "change": 0.77778
        },
        {
            "ts": "2024-06-19T02:00:00.000Z",
            "value": 35,
            "change": 1.1875
        },
        {
            "ts": "2024-06-19T03:00:00.000Z",
            "value": 52,
            "change": 0.48571
        },
        {
            "ts": "2024-06-19T04:00:00.000Z",
            "value": 18,
            "change": -0.65385
        },
        {
            "ts": "2024-06-19T05:00:00.000Z",
            "value": 30,
            "change": 0.66667
        },
        {
            "ts": "2024-06-19T06:00:00.000Z",
            "value": 43,
            "change": 0.43333
        },
        {
            "ts": "2024-06-19T07:00:00.000Z",
            "value": 52,
            "change": 0.2093
        },
        {
            "ts": "2024-06-19T08:00:00.000Z",
            "value": 28,
            "change": -0.46154
        },
        {
            "ts": "2024-06-19T09:00:00.000Z",
            "value": 28,
            "change": 0
        },
        {
            "ts": "2024-06-19T10:00:00.000Z",
            "value": 26,
            "change": -0.07143
        },
        {
            "ts": "2024-06-19T11:00:00.000Z",
            "value": 0,
            "change": -1
        }
    ]
}
```