### PR TITLE
Update metric route

### DIFF
--- a/packages/openapi/openapi.json
+++ b/packages/openapi/openapi.json
@@ -714,16 +714,36 @@
                             "description": "The URL of the AVS's X",
                             "example": "https://twitter.com/acme"
                           },
-                          "tags": {
+                          "restakeableStrategies": {
                             "type": "array",
                             "items": {
-                              "type": "string"
+                              "type": "string",
+                              "pattern": "^0x[a-fA-F0-9]{40}$"
                             },
-                            "description": "The tags associated with the AVS",
+                            "description": "The list of supported restaking strategies",
                             "example": [
-                              "DA",
-                              "DeFi"
+                              "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa1"
                             ]
+                          },
+                          "createdAtBlock": {
+                            "type": "string",
+                            "description": "The block number at which the AVS was created",
+                            "example": "19631203"
+                          },
+                          "updatedAtBlock": {
+                            "type": "string",
+                            "description": "The block number at which the AVS was last updated",
+                            "example": "19631203"
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "description": "The time stamp at which the AVS was created",
+                            "example": "2024-04-11T08:31:11.000Z"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "description": "The time stamp at which the AVS was last updated",
+                            "example": "2024-04-11T08:31:11.000Z"
                           },
                           "shares": {
                             "type": "array",
@@ -853,6 +873,11 @@
                           "metadataTelegram",
                           "metadataWebsite",
                           "metadataX",
+                          "restakeableStrategies",
+                          "createdAtBlock",
+                          "updatedAtBlock",
+                          "createdAt",
+                          "updatedAt",
                           "shares",
                           "totalOperators",
                           "totalStakers"
@@ -1131,16 +1156,36 @@
                       "description": "The URL of the AVS's X",
                       "example": "https://twitter.com/acme"
                     },
-                    "tags": {
+                    "restakeableStrategies": {
                       "type": "array",
                       "items": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^0x[a-fA-F0-9]{40}$"
                       },
-                      "description": "The tags associated with the AVS",
+                      "description": "The list of supported restaking strategies",
                       "example": [
-                        "DA",
-                        "DeFi"
+                        "0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa1"
                       ]
+                    },
+                    "createdAtBlock": {
+                      "type": "string",
+                      "description": "The block number at which the AVS was created",
+                      "example": "19631203"
+                    },
+                    "updatedAtBlock": {
+                      "type": "string",
+                      "description": "The block number at which the AVS was last updated",
+                      "example": "19631203"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "description": "The time stamp at which the AVS was created",
+                      "example": "2024-04-11T08:31:11.000Z"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "description": "The time stamp at which the AVS was last updated",
+                      "example": "2024-04-11T08:31:11.000Z"
                     },
                     "shares": {
                       "type": "array",
@@ -1270,6 +1315,11 @@
                     "metadataTelegram",
                     "metadataWebsite",
                     "metadataX",
+                    "restakeableStrategies",
+                    "createdAtBlock",
+                    "updatedAtBlock",
+                    "createdAt",
+                    "updatedAt",
                     "shares",
                     "totalOperators",
                     "totalStakers"

--- a/packages/openapi/openapi.json
+++ b/packages/openapi/openapi.json
@@ -151,6 +151,46 @@
                       "type": "number",
                       "description": "The total number of stakers",
                       "example": 10
+                    },
+                    "totalDeposits": {
+                      "type": "number",
+                      "description": "The total number of deposits",
+                      "example": 10
+                    },
+                    "HistoricalAvsCount": {
+                      "type": "number",
+                      "description": "The historical AVS count",
+                      "example": 10
+                    },
+                    "HistoricalOperatorCount": {
+                      "type": "number",
+                      "description": "The historical Operator count",
+                      "example": 10
+                    },
+                    "HistoricalStakerCount": {
+                      "type": "number",
+                      "description": "The historical Staker count",
+                      "example": 10
+                    },
+                    "HistoricalWithdrawalAggregate": {
+                      "type": "number",
+                      "description": "The historical withdrawal aggregate",
+                      "example": 10
+                    },
+                    "HistoricalDepositAggregate": {
+                      "type": "number",
+                      "description": "The historical deposit aggregate",
+                      "example": 10
+                    },
+                    "HistoricalWithdrawalCount": {
+                      "type": "number",
+                      "description": "The historical withdrawal count",
+                      "example": 10
+                    },
+                    "HistoricalDepositCount": {
+                      "type": "number",
+                      "description": "The historical deposit count",
+                      "example": 10
                     }
                   },
                   "required": [
@@ -161,7 +201,15 @@
                     "tvlBeaconChain",
                     "totalAVS",
                     "totalOperators",
-                    "totalStakers"
+                    "totalStakers",
+                    "totalDeposits",
+                    "HistoricalAvsCount",
+                    "HistoricalOperatorCount",
+                    "HistoricalStakerCount",
+                    "HistoricalWithdrawalAggregate",
+                    "HistoricalDepositAggregate",
+                    "HistoricalWithdrawalCount",
+                    "HistoricalDepositCount"
                   ]
                 }
               }

--- a/packages/openapi/openapi.json
+++ b/packages/openapi/openapi.json
@@ -2623,6 +2623,16 @@
                             "type": "number",
                             "description": "The block number when the withdrawal was last updated",
                             "example": 19912470
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "description": "The time stamp when the withdrawal was recorded by EigenExplorer",
+                            "example": "2024-07-07T23:53:35.000Z"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "description": "The time stamp when the withdrawal was last updated",
+                            "example": "2024-07-07T23:53:35.000Z"
                           }
                         },
                         "required": [
@@ -2635,7 +2645,9 @@
                           "shares",
                           "startBlock",
                           "createdAtBlock",
-                          "updatedAtBlock"
+                          "updatedAtBlock",
+                          "createdAt",
+                          "updatedAt"
                         ]
                       }
                     },
@@ -2800,6 +2812,16 @@
                       "type": "number",
                       "description": "The block number when the withdrawal was last updated",
                       "example": 19912470
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "description": "The time stamp when the withdrawal was recorded by EigenExplorer",
+                      "example": "2024-07-07T23:53:35.000Z"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "description": "The time stamp when the withdrawal was last updated",
+                      "example": "2024-07-07T23:53:35.000Z"
                     }
                   },
                   "required": [
@@ -2812,7 +2834,9 @@
                     "shares",
                     "startBlock",
                     "createdAtBlock",
-                    "updatedAtBlock"
+                    "updatedAtBlock",
+                    "createdAt",
+                    "updatedAt"
                   ]
                 }
               }
@@ -3410,6 +3434,16 @@
                             "type": "number",
                             "description": "The block number when the withdrawal was last updated",
                             "example": 19912470
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "description": "The time stamp when the withdrawal was recorded by EigenExplorer",
+                            "example": "2024-07-07T23:53:35.000Z"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "description": "The time stamp when the withdrawal was last updated",
+                            "example": "2024-07-07T23:53:35.000Z"
                           }
                         },
                         "required": [
@@ -3422,7 +3456,9 @@
                           "shares",
                           "startBlock",
                           "createdAtBlock",
-                          "updatedAtBlock"
+                          "updatedAtBlock",
+                          "createdAt",
+                          "updatedAt"
                         ]
                       }
                     },
@@ -3615,6 +3651,16 @@
                             "type": "number",
                             "description": "The block number when the withdrawal was last updated",
                             "example": 19912470
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "description": "The time stamp when the withdrawal was recorded by EigenExplorer",
+                            "example": "2024-07-07T23:53:35.000Z"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "description": "The time stamp when the withdrawal was last updated",
+                            "example": "2024-07-07T23:53:35.000Z"
                           }
                         },
                         "required": [
@@ -3627,7 +3673,9 @@
                           "shares",
                           "startBlock",
                           "createdAtBlock",
-                          "updatedAtBlock"
+                          "updatedAtBlock",
+                          "createdAt",
+                          "updatedAt"
                         ]
                       }
                     },
@@ -3820,6 +3868,16 @@
                             "type": "number",
                             "description": "The block number when the withdrawal was last updated",
                             "example": 19912470
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "description": "The time stamp when the withdrawal was recorded by EigenExplorer",
+                            "example": "2024-07-07T23:53:35.000Z"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "description": "The time stamp when the withdrawal was last updated",
+                            "example": "2024-07-07T23:53:35.000Z"
                           }
                         },
                         "required": [
@@ -3832,7 +3890,9 @@
                           "shares",
                           "startBlock",
                           "createdAtBlock",
-                          "updatedAtBlock"
+                          "updatedAtBlock",
+                          "createdAt",
+                          "updatedAt"
                         ]
                       }
                     },
@@ -4025,6 +4085,16 @@
                             "type": "number",
                             "description": "The block number when the withdrawal was last updated",
                             "example": 19912470
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "description": "The time stamp when the withdrawal was recorded by EigenExplorer",
+                            "example": "2024-07-07T23:53:35.000Z"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "description": "The time stamp when the withdrawal was last updated",
+                            "example": "2024-07-07T23:53:35.000Z"
                           }
                         },
                         "required": [
@@ -4037,7 +4107,9 @@
                           "shares",
                           "startBlock",
                           "createdAtBlock",
-                          "updatedAtBlock"
+                          "updatedAtBlock",
+                          "createdAt",
+                          "updatedAt"
                         ]
                       }
                     },

--- a/packages/openapi/src/apiResponseSchema/avs/avsResponse.ts
+++ b/packages/openapi/src/apiResponseSchema/avs/avsResponse.ts
@@ -15,11 +15,31 @@ export const AvsSchema = z.object({
     metadataTelegram: AvsMetaDataSchema.shape.metadataTelegram,
     metadataWebsite: AvsMetaDataSchema.shape.metadataWebsite,
     metadataX: AvsMetaDataSchema.shape.metadataX,
-    tags: z
-        .array(z.string())
-        .optional()
-        .describe('The tags associated with the AVS')
-        .openapi({ example: ['DA', 'DeFi'] }),
+    restakeableStrategies: z
+        .array(EthereumAddressSchema)
+        .describe('The list of supported restaking strategies')
+        .openapi({ example: ['0x35f4f28a8d3ff20eed10e087e8f96ea2641e6aa1'] }),
+    createdAtBlock: z
+        .string()
+        .describe('The block number at which the AVS was created')
+        .openapi({ example: '19631203' }),
+    updatedAtBlock: z
+        .string()
+        .describe('The block number at which the AVS was last updated')
+        .openapi({ example: '19631203' }),
+    createdAt: z
+        .string()
+        .describe('The time stamp at which the AVS was created')
+        .openapi({ example: '2024-04-11T08:31:11.000Z' }),
+    updatedAt: z
+        .string()
+        .describe('The time stamp at which the AVS was last updated')
+        .openapi({ example: '2024-04-11T08:31:11.000Z' }),
+    // tags: z
+    //     .array(z.string())
+    //     .optional()
+    //     .describe('The tags associated with the AVS')
+    //     .openapi({ example: ['DA', 'DeFi'] }),
     shares: z
         .array(StrategySharesSchema)
         .describe('The strategy shares held in the AVS')

--- a/packages/openapi/src/apiResponseSchema/metrics/summaryMetricsResponse.ts
+++ b/packages/openapi/src/apiResponseSchema/metrics/summaryMetricsResponse.ts
@@ -37,4 +37,36 @@ export const SummaryMetricsResponseSchema = z.object({
         .number()
         .describe('The total number of stakers')
         .openapi({ example: 10 }),
+    totalDeposits: z
+        .number()
+        .describe('The total number of deposits')
+        .openapi({ example: 10 }),
+    HistoricalAvsCount:z
+    .number()
+    .describe('The historical AVS count')
+    .openapi({ example: 10 }),
+    HistoricalOperatorCount:z
+    .number()
+    .describe('The historical Operator count')
+    .openapi({ example: 10 }),
+    HistoricalStakerCount:z
+    .number()
+    .describe('The historical Staker count')
+    .openapi({ example: 10 }),
+    HistoricalWithdrawalAggregate:z
+    .number()
+    .describe('The historical withdrawal aggregate')
+    .openapi({ example: 10 }),
+    HistoricalDepositAggregate:z
+    .number()
+    .describe('The historical deposit aggregate')
+    .openapi({ example: 10 }),
+    HistoricalWithdrawalCount:z
+    .number()
+    .describe('The historical withdrawal count')
+    .openapi({ example: 10 }),
+    HistoricalDepositCount:z
+    .number()
+    .describe('The historical deposit count')
+    .openapi({ example: 10 }),
 });

--- a/packages/openapi/src/apiResponseSchema/withdrawals/withdrawalsResponseSchema.ts
+++ b/packages/openapi/src/apiResponseSchema/withdrawals/withdrawalsResponseSchema.ts
@@ -55,4 +55,14 @@ export const WithdrawalsResponseSchema = z.object({
         .number()
         .describe('The block number when the withdrawal was last updated')
         .openapi({ example: 19912470 }),
+    createdAt: z
+        .string()
+        .describe(
+            'The time stamp when the withdrawal was recorded by EigenExplorer'
+        )
+        .openapi({ example: "2024-07-07T23:53:35.000Z" }),
+    updatedAt: z
+        .string()
+        .describe('The time stamp when the withdrawal was last updated')
+        .openapi({ example: "2024-07-07T23:53:35.000Z" }),
 });


### PR DESCRIPTION
add new metric route to metrics response schema, and updated openapi.json
the updated routes are listed below:
gettotalDeposits
getHistoricalAvsCount
getHistoricalOperatorCount
getHistoricalStakerCount
getHistoricalWithdrawalAggregate
getHistoricalDepositAggregate
getHistoricalWithdrawalCount
getHistoricalDepositCount
