### PR TITLE
Returning 422 Unprocessable Entity for Retrieve a strategy TVL by name endpoint

### DIFF
--- a/packages/api/src/routes/metrics/metricController.ts
+++ b/packages/api/src/routes/metrics/metricController.ts
@@ -7,7 +7,7 @@ import {
 	EigenStrategiesContractAddress,
 	getEigenContracts
 } from '../../data/address'
-import { handleAndReturnErrorResponse } from '../../schema/errors'
+import { EigenExplorerApiError, handleAndReturnErrorResponse } from '../../schema/errors'
 import { getAvsFilterQuery } from '../avs/avsController'
 import { fetchStrategyTokenPrices } from '../../utils/tokenPrices'
 import { getStrategiesWithShareUnderlying } from '../strategies/strategiesController'
@@ -80,17 +80,17 @@ export async function getTvlRestakingByStrategy(req: Request, res: Response) {
 	try {
 		const { strategy } = req.params
 
-		if (!strategy) {
-			throw new Error('Invalid strategy name.')
-		}
-
 		const strategies = Object.keys(getEigenContracts().Strategies)
 		const foundStrategy = strategies.find(
 			(s) => s.toLowerCase() === strategy.toLowerCase()
 		)
 
 		if (!foundStrategy) {
-			throw new Error('Invalid strategy.')
+			const error = new EigenExplorerApiError({
+				code: 'unprocessable_entity',
+				message: 'invalid_string: Invalid Strategy',
+			});
+			return handleAndReturnErrorResponse(req, res, error);
 		}
 
 		const tvl = await doGetTvlStrategy(

--- a/packages/api/src/routes/metrics/metricController.ts
+++ b/packages/api/src/routes/metrics/metricController.ts
@@ -86,12 +86,11 @@ export async function getTvlRestakingByStrategy(req: Request, res: Response) {
 		)
 
 		if (!foundStrategy) {
-			const error = new EigenExplorerApiError({
-				code: 'unprocessable_entity',
-				message: 'invalid_string: Invalid Strategy',
-			});
-			return handleAndReturnErrorResponse(req, res, error);
-		}
+			throw new EigenExplorerApiError({
+			  code: 'unprocessable_entity',
+			  message: 'invalid_string: Invalid Strategy',
+			})
+		  }
 
 		const tvl = await doGetTvlStrategy(
 			getEigenContracts().Strategies[foundStrategy].strategyContract


### PR DESCRIPTION
Current the endpoint `Retrieve a strategy TVL by name` returns 
`500 - Internal Server Error` when the parameter `strategy` is any invalid value
The expected behavior should be to return `422 Unprocessable Entity` in this case 