### PR TITLE
[Feat] - Add change to TVL, Beacon TVL & Restaking TVL routes

### DIFF
--- a/packages/api/src/routes/metrics/metricController.ts
+++ b/packages/api/src/routes/metrics/metricController.ts
@@ -253,7 +253,7 @@ export async function getTvlRestaking(req: Request, res: Response) {
 		res.send({
 			...(withChange
 				? { ...(tvlResponse.tvlRestaking as TvlWithChange) }
-				: { tvlRestaking: tvlResponse.tvlRestaking as TvlWithoutChange }),
+				: { tvl: tvlResponse.tvlRestaking as TvlWithoutChange }),
 			tvlStrategies: tvlResponse.tvlStrategies,
 			tvlStrategiesEth: tvlResponse.tvlStrategiesEth
 		})

--- a/packages/api/src/routes/metrics/metricController.ts
+++ b/packages/api/src/routes/metrics/metricController.ts
@@ -17,6 +17,7 @@ import { getContract } from 'viem'
 import { strategyAbi } from '../../data/abi/strategy'
 import { getViemClient } from '../../viem/viemClient'
 import { getStrategiesWithShareUnderlying } from '../strategies/strategiesController'
+import { WithChangeQuerySchema } from '../../schema/zod/schemas/withChangeQuery'
 
 type TvlWithoutChange = number
 
@@ -130,8 +131,13 @@ export async function getMetrics(req: Request, res: Response) {
  * @param res
  */
 export async function getTvl(req: Request, res: Response) {
+	const queryCheck = WithChangeQuerySchema.safeParse(req.query)
+	if (!queryCheck.success) {
+		return handleAndReturnErrorResponse(req, res, queryCheck.error)
+	}
+
 	try {
-		const withChange = true // TODO
+		const { withChange }  = queryCheck.data
 		const tvlRestaking = (await doGetTvl(withChange)).tvlRestaking
 		const tvlBeaconChain = await doGetTvlBeaconChain(withChange)
 
@@ -162,8 +168,13 @@ export async function getTvl(req: Request, res: Response) {
  * @param res
  */
 export async function getTvlBeaconChain(req: Request, res: Response) {
+	const queryCheck = WithChangeQuerySchema.safeParse(req.query)
+	if (!queryCheck.success) {
+		return handleAndReturnErrorResponse(req, res, queryCheck.error)
+	}
+
 	try {
-		const withChange = true // TODO
+		const { withChange }  = queryCheck.data
 		const tvlBeaconChain = await doGetTvlBeaconChain(withChange)
 
 		res.send({
@@ -185,8 +196,13 @@ export async function getTvlBeaconChain(req: Request, res: Response) {
  * @param res
  */
 export async function getTvlRestaking(req: Request, res: Response) {
+	const queryCheck = WithChangeQuerySchema.safeParse(req.query)
+	if (!queryCheck.success) {
+		return handleAndReturnErrorResponse(req, res, queryCheck.error)
+	}
+
 	try {
-		const withChange = true //TODO
+		const { withChange }  = queryCheck.data
 		const tvlResponse = await doGetTvl(withChange)
 
 		res.send({
@@ -209,9 +225,14 @@ export async function getTvlRestaking(req: Request, res: Response) {
  * @param res
  */
 export async function getTvlRestakingByStrategy(req: Request, res: Response) {
+	const queryCheck = WithChangeQuerySchema.safeParse(req.query)
+	if (!queryCheck.success) {
+		return handleAndReturnErrorResponse(req, res, queryCheck.error)
+	}
+
 	try {
+		const { withChange }  = queryCheck.data
 		const { strategy } = req.params
-		const withChange = true //TODO
 
 		const strategies = Object.keys(getEigenContracts().Strategies)
 		const foundStrategy = strategies.find(

--- a/packages/api/src/routes/metrics/metricController.ts
+++ b/packages/api/src/routes/metrics/metricController.ts
@@ -78,7 +78,6 @@ type EthTvlModelMap = {
 	metricDepositHourly: Prisma.MetricDepositHourly
 	metricWithdrawalHourly: Prisma.MetricWithdrawalHourly
 	metricEigenPodsHourly: Prisma.MetricEigenPodsHourly
-	validator: Prisma.Validator
 }
 type EthTvlModelName = keyof EthTvlModelMap // Models with TVL denominated in ETH
 
@@ -965,7 +964,7 @@ async function doGetTvlBeaconChain(
 	const currentTvl = Number(totalValidators._sum.balance) / 1e9
 
 	return withChange
-		? ((await calculateTvlChange(currentTvl, 'validator')) as TvlWithChange)
+		? ((await calculateTvlChange(currentTvl, 'metricEigenPodsHourly')) as TvlWithChange)
 		: (currentTvl as TvlWithoutChange)
 }
 
@@ -2244,8 +2243,7 @@ function checkEthDenomination(modelName: string): modelName is EthTvlModelName {
 	const ethTvlModelNames: EthTvlModelName[] = [
 		'metricDepositHourly',
 		'metricWithdrawalHourly',
-		'metricEigenPodsHourly',
-		'validator'
+		'metricEigenPodsHourly'
 	]
 	return ethTvlModelNames.includes(modelName as EthTvlModelName)
 }

--- a/packages/api/src/schema/zod/schemas/withChangeQuery.ts
+++ b/packages/api/src/schema/zod/schemas/withChangeQuery.ts
@@ -1,0 +1,10 @@
+import z from '..'
+
+export const WithChangeQuerySchema = z.object({
+	withChange: z
+		.enum(['true', 'false'])
+		.default('false')
+		.describe('Toggle whether the route should return 24h/7d change for TVL')
+		.transform((val) => val === 'true')
+		.openapi({ example: 'false' })
+})


### PR DESCRIPTION
Added 24h & 7d change (percent & values) to the following routes, accessible via `withChange` flag:
```
/metrics
    /tvl 
    /tvl/beacon-chain 
    /tvl/restaking 
    /tvl/restaking/:strategy 
    /total-avs
    /total-operators
    /total-stakers
    /total-withdrawals
    /total-deposits
 ```
 
Hierarchy of response structures remain the same when calling these routes setting `withChange=true` flag except for `/metrics/total-withdrawals`, for which each key has been turned into an object