### PR TITLE
Update search routes to accommodate better table search UX

### DIFF
--- a/packages/api/src/routes/avs/avsController.ts
+++ b/packages/api/src/routes/avs/avsController.ts
@@ -69,9 +69,7 @@ export async function getAllAVS(req: Request, res: Response) {
 						{
 							curatedMetadata: {
 								is: {
-									OR: [
-										{ metadataName: searchConfig },
-									]
+									OR: [{ metadataName: searchConfig }]
 								}
 							}
 						}
@@ -112,9 +110,7 @@ export async function getAllAVS(req: Request, res: Response) {
 								{
 									curatedMetadata: {
 										is: {
-											OR: [
-												{ metadataName: searchConfig },
-											]
+											OR: [{ metadataName: searchConfig }]
 										}
 									}
 								}

--- a/packages/api/src/routes/avs/avsController.ts
+++ b/packages/api/src/routes/avs/avsController.ts
@@ -66,15 +66,11 @@ export async function getAllAVS(req: Request, res: Response) {
 					OR: [
 						{ address: searchConfig },
 						{ metadataName: searchConfig },
-						{ metadataDescription: searchConfig },
-						{ metadataWebsite: searchConfig },
 						{
 							curatedMetadata: {
 								is: {
 									OR: [
 										{ metadataName: searchConfig },
-										{ metadataDescription: searchConfig },
-										{ metadataWebsite: searchConfig }
 									]
 								}
 							}
@@ -106,7 +102,26 @@ export async function getAllAVS(req: Request, res: Response) {
 
 		// Fetch count
 		const avsCount = searchByText
-			? avsRecords.length
+			? await prisma.avs.count({
+					where: {
+						...getAvsFilterQuery(true),
+						...(searchByText && {
+							OR: [
+								{ address: searchConfig },
+								{ metadataName: searchConfig },
+								{
+									curatedMetadata: {
+										is: {
+											OR: [
+												{ metadataName: searchConfig },
+											]
+										}
+									}
+								}
+							] as Prisma.Prisma.AvsWhereInput[]
+						})
+					}
+			  })
 			: await prisma.avs.count({
 					where: getAvsFilterQuery(true)
 			  })

--- a/packages/api/src/routes/avs/avsController.ts
+++ b/packages/api/src/routes/avs/avsController.ts
@@ -240,7 +240,28 @@ export async function getAllAVSAddresses(req: Request, res: Response) {
 
 		// Determine count
 		const avsCount = searchByText
-			? avsRecords.length
+			? await prisma.avs.count({
+					where: {
+						...getAvsFilterQuery(true),
+						OR: [
+							{ address: searchConfig },
+							{ metadataName: searchConfig },
+							{ metadataDescription: searchConfig },
+							{ metadataWebsite: searchConfig },
+							{
+								curatedMetadata: {
+									is: {
+										OR: [
+											{ metadataName: searchConfig },
+											{ metadataDescription: searchConfig },
+											{ metadataWebsite: searchConfig }
+										]
+									}
+								}
+							}
+						] as Prisma.Prisma.AvsWhereInput[]
+					}
+			  })
 			: await prisma.avs.count({
 					where: getAvsFilterQuery(true)
 			  })

--- a/packages/api/src/routes/operators/operatorController.ts
+++ b/packages/api/src/routes/operators/operatorController.ts
@@ -66,9 +66,7 @@ export async function getAllOperators(req: Request, res: Response) {
 				where: {
 					OR: [
 						{ address: searchConfig },
-						{ metadataName: searchConfig },
-						{ metadataDescription: searchConfig },
-						{ metadataWebsite: searchConfig }
+						{ metadataName: searchConfig }
 					] as Prisma.Prisma.OperatorWhereInput[]
 				}
 			}),
@@ -83,7 +81,14 @@ export async function getAllOperators(req: Request, res: Response) {
 
 		// Count records
 		const operatorCount = searchByText
-			? operatorRecords.length
+			? await prisma.operator.count({
+					where: {
+						OR: [
+							{ address: searchConfig },
+							{ metadataName: searchConfig }
+						] as Prisma.Prisma.OperatorWhereInput[]
+					}
+			  })
 			: await prisma.operator.count()
 
 		const strategyTokenPrices = withTvl ? await fetchStrategyTokenPrices() : {}
@@ -270,7 +275,16 @@ export async function getAllOperatorAddresses(req: Request, res: Response) {
 
 		// Determine count
 		const operatorCount = searchByText
-			? operatorRecords.length
+			? await prisma.operator.count({
+					where: {
+						OR: [
+							{ address: searchConfig },
+							{ metadataName: searchConfig },
+							{ metadataDescription: searchConfig },
+							{ metadataWebsite: searchConfig }
+						] as Prisma.Prisma.OperatorWhereInput[]
+					}
+			  })
 			: await prisma.operator.count()
 
 		const data = operatorRecords.map((operator) => ({

--- a/packages/api/src/schema/zod/schemas/searchByTextQuery.ts
+++ b/packages/api/src/schema/zod/schemas/searchByTextQuery.ts
@@ -7,10 +7,10 @@ export const SearchByTextQuerySchema = z.object({
 		.refine(
 			(value) => {
 				if (!value) return true
-				return value.length >= 3 && value.length <= 64
+				return value.length >= 1 && value.length <= 64
 			},
 			{
-				message: 'Search query must be between 3 and 64 characters long.'
+				message: 'Search query must be between 1 and 64 characters long.'
 			}
 		)
 		.refine(

--- a/packages/api/src/schema/zod/schemas/searchByTextQuery.ts
+++ b/packages/api/src/schema/zod/schemas/searchByTextQuery.ts
@@ -1,39 +1,51 @@
 import z from '../'
 
-export const SearchByTextQuerySchema = z.object({
-	searchByText: z
-		.string()
-		.optional()
-		.refine(
-			(value) => {
-				if (!value) return true
-				return value.length >= 3 && value.length <= 64
-			},
-			{
-				message: 'Search query must be between 3 and 64 characters long.'
+export const SearchByTextQuerySchema = z
+	.object({
+		searchMode: z
+			.enum(['contains', 'startsWith'])
+			.optional()
+			.default('contains')
+			.describe('Search mode')
+			.openapi({ example: 'contains' }),
+		searchByText: z
+			.string()
+			.optional()
+			.refine(
+				(value) => {
+					if (!value) return true
+					return /^[a-zA-Z0-9\s.,?-]+$/.test(value)
+				},
+				{
+					message:
+						"Only letters, numbers, spaces, and basic punctuation marks ['.' | ',' | '?' | '-'] are allowed."
+				}
+			)
+			.refine(
+				(value) => {
+					if (!value) return true
+					return !/<[^>]*>/.test(value)
+				},
+				{ message: 'HTML tags are not allowed.' }
+			)
+			.transform((value) => {
+				if (!value) return value
+				return value.trim().split(/\s+/).join('&') // Replace spaces with '&' for tsquery compatibility
+			})
+			.describe('Case-insensitive search query')
+			.openapi({ example: 'blockless' })
+	})
+	.refine(
+		(data) => {
+			if (!data.searchByText) return true
+
+			if (data.searchMode === 'contains') {
+				return data.searchByText.length >= 3 && data.searchByText.length <= 64
 			}
-		)
-		.refine(
-			(value) => {
-				if (!value) return true
-				return /^[a-zA-Z0-9\s.,?-]+$/.test(value)
-			},
-			{
-				message:
-					"Only letters, numbers, spaces, and basic punctuation marks ['.' | ',' | '?' | '-'] are allowed."
-			}
-		)
-		.refine(
-			(value) => {
-				if (!value) return true
-				return !/<[^>]*>/.test(value)
-			},
-			{ message: 'HTML tags are not allowed.' }
-		)
-		.transform((value) => {
-			if (!value) return value
-			return value.trim().split(/\s+/).join('&') // Replace spaces with '&' for tsquery compatibility
-		})
-		.describe('Case-insensitive search query')
-		.openapi({ example: 'blockless' })
-})
+
+			return true
+		},
+		{
+			message: 'Search query must be between 3 and 64 characters long.'
+		}
+	)

--- a/packages/api/src/schema/zod/schemas/searchByTextQuery.ts
+++ b/packages/api/src/schema/zod/schemas/searchByTextQuery.ts
@@ -7,10 +7,10 @@ export const SearchByTextQuerySchema = z.object({
 		.refine(
 			(value) => {
 				if (!value) return true
-				return value.length >= 1 && value.length <= 64
+				return value.length >= 3 && value.length <= 64
 			},
 			{
-				message: 'Search query must be between 1 and 64 characters long.'
+				message: 'Search query must be between 3 and 64 characters long.'
 			}
 		)
 		.refine(


### PR DESCRIPTION
- For Search routes used by tables (`/avs/:address/operators?searchByText=`, `/avs?searchByText=` & `/operators?searchByText=`, search fields are restricted to `metadataName`

- In the meta of the response,`total` now provides the total number of search results rather than the length of the response array. This is helpful when pagination is required whilst searching.