### PR TITLE
Staker Event API V1

### DIFF
--- a/packages/api/src/routes/stakers/stakerController.ts
+++ b/packages/api/src/routes/stakers/stakerController.ts
@@ -7,6 +7,59 @@ import { getViemClient } from '../../viem/viemClient'
 import { getStrategiesWithShareUnderlying, sharesToTVL } from '../../utils/strategyShares'
 import { EthereumAddressSchema } from '../../schema/zod/schemas/base/ethereumAddress'
 import { UpdatedSinceQuerySchema } from '../../schema/zod/schemas/updatedSinceQuery'
+import {
+	DelegationStakerEventQuerySchema,
+	DepositStakerEventQuerySchema,
+	WithdrawalStakerEventQuerySchema
+} from '../../schema/zod/schemas/stakerEvents'
+
+type EventRecord = {
+	type: string
+	tx: string
+	blockNumber: number
+	blockTime: Date
+	args: EventArgs
+	underlyingToken?: string
+	underlyingValue?: number
+	ethValue?: number
+}
+
+type EventArgs = DelegationArgs | DepositArgs | WithdrawalArgs
+
+type DelegationArgs = {
+	operator: string
+	strategy?: string
+	shares?: number
+}
+
+type DepositArgs = {
+	token: string
+	strategy: string
+	shares: number
+}
+
+type WithdrawalArgs = {
+	withdrawalRoot: string
+	delegatedTo?: string
+	withdrawer?: string
+	nonce?: number
+	startBlock?: number
+	strategies?: {
+		strategy: string
+		shares: number
+		underlyingToken?: string
+		underlyingValue?: number
+		ethValue?: number
+	}[]
+}
+
+type DetailedStrategyData = {
+	strategy: string
+	shares: number
+	underlyingToken?: string
+	underlyingValue?: number
+	ethValue?: number
+}
 
 /**
  * Route to get a list of all stakers
@@ -395,5 +448,519 @@ export async function getStakerDeposits(req: Request, res: Response) {
 		})
 	} catch (error) {
 		handleAndReturnErrorResponse(req, res, error)
+	}
+}
+
+/**
+ * Function for route /stakers/:address/events/delegation
+ * Fetches and returns a list of delegation-related events for a specific staker with optional filters
+ *
+ * @param req
+ * @param res
+ */
+export async function getStakerDelegationEvents(req: Request, res: Response) {
+	const result = DelegationStakerEventQuerySchema.and(PaginationQuerySchema).safeParse(req.query)
+	if (!result.success) return handleAndReturnErrorResponse(req, res, result.error)
+
+	try {
+		const {
+			type,
+			operator,
+			strategyAddress,
+			txHash,
+			startAt,
+			endAt,
+			skip,
+			take,
+			withTokenData,
+			withEthValue
+		} = result.data
+		const { address } = req.params
+
+		const baseFilterQuery = {
+			staker: {
+				contains: address,
+				mode: 'insensitive'
+			},
+			...(operator && {
+				operator: {
+					contains: operator,
+					mode: 'insensitive'
+				}
+			}),
+			...(strategyAddress && {
+				strategy: {
+					contains: strategyAddress,
+					mode: 'insensitive'
+				}
+			}),
+			...(txHash && {
+				transactionHash: {
+					contains: txHash,
+					mode: 'insensitive'
+				}
+			}),
+			blockTime: {
+				gte: new Date(startAt as string),
+				...(endAt ? { lte: new Date(endAt as string) } : {})
+			}
+		}
+
+		const eventTypes = type
+			? [type]
+			: strategyAddress
+			? ['SHARES_INCREASED', 'SHARES_DECREASED']
+			: ['SHARES_INCREASED', 'SHARES_DECREASED', 'DELEGATION', 'UNDELEGATION']
+
+		const results = await Promise.all(
+			eventTypes.map((eventType) =>
+				fetchAndMapStakerEvents(eventType, baseFilterQuery, withTokenData, withEthValue, skip, take)
+			)
+		)
+
+		const eventRecords = results.flatMap((result) => result.eventRecords)
+		const eventCount = results.reduce((acc, result) => acc + result.eventCount, 0)
+
+		res.send({
+			data: eventRecords,
+			meta: { total: eventCount, skip, take }
+		})
+	} catch (error) {
+		handleAndReturnErrorResponse(req, res, error)
+	}
+}
+
+/**
+ * Function for route /stakers/:address/events/deposit
+ * Fetches and returns a list of deposit events for a specific staker with optional filters
+ *
+ * @param req
+ * @param res
+ */
+export async function getStakerDepositEvents(req: Request, res: Response) {
+	const result = DepositStakerEventQuerySchema.and(PaginationQuerySchema).safeParse(req.query)
+	if (!result.success) return handleAndReturnErrorResponse(req, res, result.error)
+
+	try {
+		const { txHash, startAt, endAt, token, strategy, skip, take, withTokenData, withEthValue } =
+			result.data
+		const { address } = req.params
+
+		const baseFilterQuery = {
+			staker: {
+				contains: address,
+				mode: 'insensitive'
+			},
+			...(token && {
+				token: {
+					contains: token,
+					mode: 'insensitive'
+				}
+			}),
+			...(strategy && {
+				strategy: {
+					contains: strategy,
+					mode: 'insensitive'
+				}
+			}),
+			...(txHash && {
+				transactionHash: {
+					contains: txHash,
+					mode: 'insensitive'
+				}
+			}),
+			blockTime: {
+				gte: new Date(startAt as string),
+				...(endAt ? { lte: new Date(endAt as string) } : {})
+			}
+		}
+
+		const results = await fetchAndMapStakerEvents(
+			'DEPOSIT',
+			baseFilterQuery,
+			withTokenData,
+			withEthValue,
+			skip,
+			take
+		)
+
+		res.send({
+			data: results.eventRecords,
+			meta: { total: results.eventCount, skip, take }
+		})
+	} catch (error) {
+		handleAndReturnErrorResponse(req, res, error)
+	}
+}
+
+/**
+ * Function for route /stakers/:address/events/withdrawal
+ * Fetches and returns a list of withdrawal-related events for a specific staker with optional filters
+ *
+ * @param req
+ * @param res
+ */
+export async function getStakerWithdrawalEvents(req: Request, res: Response) {
+	const result = WithdrawalStakerEventQuerySchema.and(PaginationQuerySchema).safeParse(req.query)
+	if (!result.success) return handleAndReturnErrorResponse(req, res, result.error)
+
+	try {
+		const {
+			type,
+			txHash,
+			startAt,
+			endAt,
+			withdrawalRoot,
+			delegatedTo,
+			withdrawer,
+			skip,
+			take,
+			withTokenData,
+			withEthValue
+		} = result.data
+		const { address } = req.params
+
+		let queuedEvents: EventRecord[] = []
+		let completedEvents: EventRecord[] = []
+
+		const queuedFilterQuery = {
+			staker: {
+				contains: address,
+				mode: 'insensitive'
+			},
+			...(withdrawalRoot && {
+				withdrawalRoot: {
+					contains: withdrawalRoot,
+					mode: 'insensitive'
+				}
+			}),
+			...(delegatedTo && {
+				delegatedTo: {
+					contains: delegatedTo,
+					mode: 'insensitive'
+				}
+			}),
+			...(withdrawer && {
+				withdrawer: {
+					contains: withdrawer,
+					mode: 'insensitive'
+				}
+			}),
+			...(txHash && {
+				transactionHash: {
+					contains: txHash,
+					mode: 'insensitive'
+				}
+			}),
+			blockTime: {
+				gte: new Date(startAt as string),
+				...(endAt ? { lte: new Date(endAt as string) } : {})
+			}
+		}
+
+		const completedFilterQuery = {
+			...(withdrawalRoot && {
+				withdrawalRoot: {
+					contains: withdrawalRoot,
+					mode: 'insensitive'
+				}
+			}),
+			...(txHash && {
+				transactionHash: {
+					contains: txHash,
+					mode: 'insensitive'
+				}
+			})
+		}
+
+		if (txHash) {
+			const queuedResult = await fetchAndMapStakerEvents(
+				'WITHDRAWAL_QUEUED',
+				queuedFilterQuery,
+				withTokenData,
+				withEthValue,
+				skip,
+				take
+			)
+
+			if (queuedResult.eventRecords.length > 0) {
+				return res.send({
+					data: queuedResult.eventRecords,
+					meta: { total: queuedResult.eventRecords.length, skip, take }
+				})
+			}
+
+			const completedResult = await fetchAndMapStakerEvents(
+				'WITHDRAWAL_COMPLETED',
+				completedFilterQuery,
+				withTokenData,
+				withEthValue,
+				skip,
+				take
+			)
+
+			return res.send({
+				data: completedResult.eventRecords,
+				meta: { total: completedResult.eventRecords.length, skip, take }
+			})
+		}
+
+		if (type === 'WITHDRAWAL_COMPLETED' && (withdrawalRoot || txHash)) {
+			const completedResult = await fetchAndMapStakerEvents(
+				'WITHDRAWAL_COMPLETED',
+				completedFilterQuery,
+				withTokenData,
+				withEthValue,
+				skip,
+				take
+			)
+			return res.send({
+				data: completedResult.eventRecords,
+				meta: { total: completedResult.eventRecords.length, skip, take }
+			})
+		}
+
+		if (type === 'WITHDRAWAL_QUEUED') {
+			const queuedResult = await fetchAndMapStakerEvents(
+				'WITHDRAWAL_QUEUED',
+				queuedFilterQuery,
+				withTokenData,
+				withEthValue,
+				skip,
+				take
+			)
+			return res.send({
+				data: queuedResult.eventRecords,
+				meta: { total: queuedResult.eventRecords.length, skip, take }
+			})
+		}
+
+		// Default case: Fetch queued events, then use withdrawalRoots for completed events
+		const queuedResult = await fetchAndMapStakerEvents(
+			'WITHDRAWAL_QUEUED',
+			queuedFilterQuery,
+			withTokenData,
+			withEthValue,
+			skip,
+			take
+		)
+		queuedEvents = queuedResult.eventRecords
+
+		const withdrawalRoots = queuedEvents
+			.map((event) => (event.args as WithdrawalArgs).withdrawalRoot)
+			.filter((root): root is string => root !== undefined)
+
+		if (withdrawalRoots.length) {
+			const completedResult = await fetchAndMapStakerEvents(
+				'WITHDRAWAL_COMPLETED',
+				{ withdrawalRoot: { in: withdrawalRoots } },
+				withTokenData,
+				withEthValue,
+				skip,
+				take
+			)
+			completedEvents = completedResult.eventRecords
+		}
+
+		const eventRecords =
+			type === 'WITHDRAWAL_COMPLETED' ? completedEvents : [...queuedEvents, ...completedEvents]
+		res.send({
+			data: eventRecords,
+			meta: { total: eventRecords.length, skip, take }
+		})
+	} catch (error) {
+		handleAndReturnErrorResponse(req, res, error)
+	}
+}
+
+// --- Helper functions ---
+
+/**
+ * Utility function to calculate underlying token data and ETH values for a strategy.
+ *
+ * @param strategyAddress
+ * @param shares
+ * @returns
+ */
+async function calculateStrategyData(
+	strategyAddress: string,
+	shares: bigint
+): Promise<{ underlyingToken?: string; underlyingValue?: number; ethValue?: number }> {
+	let underlyingToken: string | undefined
+	let underlyingValue: number | undefined
+	let ethValue: number | undefined
+
+	const strategy = await prisma.strategies.findUnique({
+		where: { address: strategyAddress.toLowerCase() }
+	})
+
+	const strategiesWithSharesUnderlying = await getStrategiesWithShareUnderlying()
+
+	if (strategy && strategiesWithSharesUnderlying) {
+		underlyingToken = strategy.underlyingToken
+		const sharesUnderlying = strategiesWithSharesUnderlying.find(
+			(s) => s.strategyAddress.toLowerCase() === strategyAddress.toLowerCase()
+		)
+
+		if (sharesUnderlying) {
+			underlyingValue =
+				Number((shares * BigInt(sharesUnderlying.sharesToUnderlying)) / BigInt(1e18)) / 1e18
+
+			if (sharesUnderlying.ethPrice) {
+				ethValue = underlyingValue * sharesUnderlying.ethPrice
+			}
+		}
+	}
+
+	return { underlyingToken, underlyingValue, ethValue }
+}
+
+/**
+ * Utility function to fetch and map event records from the database.
+ *
+ * @param eventType
+ * @param baseFilterQuery
+ * @param withTokenData
+ * @param withEthValue
+ * @param skip
+ * @param take
+ * @returns
+ */
+async function fetchAndMapStakerEvents(
+	eventType: string,
+	baseFilterQuery: any,
+	withTokenData: boolean,
+	withEthValue: boolean,
+	skip: number,
+	take: number
+): Promise<{ eventRecords: EventRecord[]; eventCount: number }> {
+	const modelName = (() => {
+		switch (eventType) {
+			case 'DEPOSIT':
+				return 'eventLogs_Deposit'
+			case 'SHARES_INCREASED':
+				return 'eventLogs_OperatorSharesIncreased'
+			case 'SHARES_DECREASED':
+				return 'eventLogs_OperatorSharesDecreased'
+			case 'DELEGATION':
+				return 'eventLogs_StakerDelegated'
+			case 'UNDELEGATION':
+				return 'eventLogs_StakerUndelegated'
+			case 'WITHDRAWAL_QUEUED':
+				return 'eventLogs_WithdrawalQueued'
+			case 'WITHDRAWAL_COMPLETED':
+				return 'eventLogs_WithdrawalCompleted'
+			default:
+				throw new Error(`Unknown event type: ${eventType}`)
+		}
+	})()
+
+	const model = prisma[modelName] as any
+	const eventCount = await model.count({ where: baseFilterQuery })
+
+	const eventRecords = await model.findMany({
+		where: baseFilterQuery,
+		skip,
+		take,
+		orderBy: { blockNumber: 'desc' }
+	})
+
+	const detailedEventRecords = await Promise.all(
+		eventRecords.map(async (event) => {
+			const detailedStrategies: DetailedStrategyData[] = []
+			let underlyingToken: string | undefined
+			let underlyingValue: number | undefined
+			let ethValue: number | undefined
+
+			if (withTokenData && eventType === 'WITHDRAWAL_QUEUED' && event.strategies) {
+				for (const [index, strategyAddress] of event.strategies.entries()) {
+					const detailedData = await calculateStrategyData(
+						strategyAddress,
+						BigInt(event.shares[index])
+					)
+
+					console.log('withEthValue', withEthValue)
+
+					const strategyData = {
+						strategy: strategyAddress,
+						shares: event.shares[index],
+						underlyingToken: detailedData.underlyingToken,
+						underlyingValue: detailedData.underlyingValue,
+						...(withEthValue ? { ethValue: detailedData.ethValue } : {})
+					}
+					detailedStrategies.push(strategyData)
+				}
+			} else if (
+				withTokenData &&
+				(eventType === 'SHARES_INCREASED' ||
+					eventType === 'SHARES_DECREASED' ||
+					eventType === 'DEPOSIT') &&
+				event.strategy
+			) {
+				const detailedData = await calculateStrategyData(event.strategy, BigInt(event.shares))
+				underlyingToken = detailedData.underlyingToken
+				underlyingValue = detailedData.underlyingValue
+				ethValue = detailedData.ethValue
+			}
+
+			return {
+				type: eventType,
+				tx: event.transactionHash,
+				blockNumber: event.blockNumber,
+				blockTime: event.blockTime,
+				args: {
+					...mapEventArgs(event, eventType),
+					...(detailedStrategies.length > 0 && { strategies: detailedStrategies })
+				},
+				...(underlyingToken && { underlyingToken }),
+				...(underlyingValue !== undefined && { underlyingValue }),
+				...(withEthValue && ethValue !== undefined && { ethValue })
+			}
+		})
+	)
+
+	return {
+		eventRecords: detailedEventRecords,
+		eventCount
+	}
+}
+
+/**
+ * Utility function to map raw database event data to structured event arguments.
+ *
+ * @param event
+ * @param eventType
+ * @returns
+ */
+function mapEventArgs(event: any, eventType: string): EventArgs {
+	switch (eventType) {
+		case 'DEPOSIT':
+			return {
+				token: event.token,
+				strategy: event.strategy,
+				shares: event.shares
+			}
+		case 'WITHDRAWAL_QUEUED':
+			return {
+				withdrawalRoot: event.withdrawalRoot,
+				delegatedTo: event.delegatedTo,
+				withdrawer: event.withdrawer,
+				nonce: event.nonce,
+				startBlock: event.startBlock,
+				strategies: event.strategies.map((strategyAddress: string, index: number) => ({
+					strategy: strategyAddress,
+					shares: event.shares[index]
+				}))
+			}
+		case 'WITHDRAWAL_COMPLETED':
+			return {
+				withdrawalRoot: event.withdrawalRoot
+			}
+		default:
+			return {
+				operator: event.operator,
+				strategy: event.strategy,
+				shares: event.shares
+			}
 	}
 }

--- a/packages/api/src/routes/stakers/stakerController.ts
+++ b/packages/api/src/routes/stakers/stakerController.ts
@@ -13,15 +13,23 @@ import {
 	WithdrawalStakerEventQuerySchema
 } from '../../schema/zod/schemas/stakerEvents'
 
+type UnderlyingTokenDetails = {
+	underlyingToken?: string
+	underlyingValue?: number
+	ethValue?: number
+}
+
+type StrategyData = {
+	strategy: string
+	shares: number
+} & UnderlyingTokenDetails
+
 type EventRecord = {
 	type: string
 	tx: string
 	blockNumber: number
 	blockTime: Date
 	args: EventArgs
-	underlyingToken?: string
-	underlyingValue?: number
-	ethValue?: number
 }
 
 type EventArgs = DelegationArgs | DepositArgs | WithdrawalArgs
@@ -30,13 +38,13 @@ type DelegationArgs = {
 	operator: string
 	strategy?: string
 	shares?: number
-}
+} & UnderlyingTokenDetails
 
 type DepositArgs = {
 	token: string
 	strategy: string
 	shares: number
-}
+} & UnderlyingTokenDetails
 
 type WithdrawalArgs = {
 	withdrawalRoot: string
@@ -44,21 +52,7 @@ type WithdrawalArgs = {
 	withdrawer?: string
 	nonce?: number
 	startBlock?: number
-	strategies?: {
-		strategy: string
-		shares: number
-		underlyingToken?: string
-		underlyingValue?: number
-		ethValue?: number
-	}[]
-}
-
-type DetailedStrategyData = {
-	strategy: string
-	shares: number
-	underlyingToken?: string
-	underlyingValue?: number
-	ethValue?: number
+	strategies?: StrategyData[]
 }
 
 /**
@@ -867,7 +861,7 @@ async function fetchAndMapStakerEvents(
 
 	const detailedEventRecords = await Promise.all(
 		eventRecords.map(async (event) => {
-			const detailedStrategies: DetailedStrategyData[] = []
+			const detailedStrategies: StrategyData[] = []
 			let underlyingToken: string | undefined
 			let underlyingValue: number | undefined
 			let ethValue: number | undefined
@@ -878,8 +872,6 @@ async function fetchAndMapStakerEvents(
 						strategyAddress,
 						BigInt(event.shares[index])
 					)
-
-					console.log('withEthValue', withEthValue)
 
 					const strategyData = {
 						strategy: strategyAddress,

--- a/packages/api/src/routes/stakers/stakerController.ts
+++ b/packages/api/src/routes/stakers/stakerController.ts
@@ -459,7 +459,7 @@ export async function getStakerDelegationEvents(req: Request, res: Response) {
 	try {
 		const {
 			type,
-			operator,
+			operatorAddress,
 			strategyAddress,
 			txHash,
 			startAt,
@@ -476,9 +476,9 @@ export async function getStakerDelegationEvents(req: Request, res: Response) {
 				contains: address,
 				mode: 'insensitive'
 			},
-			...(operator && {
+			...(operatorAddress && {
 				operator: {
-					contains: operator,
+					contains: operatorAddress,
 					mode: 'insensitive'
 				}
 			}),
@@ -550,8 +550,17 @@ export async function getStakerDepositEvents(req: Request, res: Response) {
 	if (!result.success) return handleAndReturnErrorResponse(req, res, result.error)
 
 	try {
-		const { txHash, startAt, endAt, token, strategy, skip, take, withTokenData, withEthValue } =
-			result.data
+		const {
+			txHash,
+			startAt,
+			endAt,
+			tokenAddress,
+			strategyAddress,
+			skip,
+			take,
+			withTokenData,
+			withEthValue
+		} = result.data
 		const { address } = req.params
 
 		const baseFilterQuery = {
@@ -559,15 +568,15 @@ export async function getStakerDepositEvents(req: Request, res: Response) {
 				contains: address,
 				mode: 'insensitive'
 			},
-			...(token && {
+			...(tokenAddress && {
 				token: {
-					contains: token,
+					contains: tokenAddress,
 					mode: 'insensitive'
 				}
 			}),
-			...(strategy && {
+			...(strategyAddress && {
 				strategy: {
-					contains: strategy,
+					contains: strategyAddress,
 					mode: 'insensitive'
 				}
 			}),

--- a/packages/api/src/routes/stakers/stakerController.ts
+++ b/packages/api/src/routes/stakers/stakerController.ts
@@ -667,51 +667,22 @@ export async function getStakerWithdrawalEvents(req: Request, res: Response) {
 			})
 		}
 
-		if (txHash) {
-			const queuedResult = await fetchAndMapStakerEvents(
-				'WITHDRAWAL_QUEUED',
-				queuedFilterQuery,
+		if (txHash || (type === 'WITHDRAWAL_COMPLETED' && withdrawalRoot)) {
+			const completedResult = await fetchAndMapStakerEvents(
+				'WITHDRAWAL_COMPLETED',
+				completedFilterQuery,
 				withTokenData,
 				withEthValue,
 				skip,
 				take
 			)
 
-			if (queuedResult.eventRecords.length > 0) {
+			if (completedResult.eventRecords.length > 0 && type != 'WITHDRAWAL_QUEUED') {
 				return res.send({
-					data: queuedResult.eventRecords,
-					meta: { total: queuedResult.eventCount, skip, take }
+					data: completedResult.eventRecords,
+					meta: { total: completedResult.eventCount, skip, take }
 				})
 			}
-
-			const completedResult = await fetchAndMapStakerEvents(
-				'WITHDRAWAL_COMPLETED',
-				completedFilterQuery,
-				withTokenData,
-				withEthValue,
-				skip,
-				take
-			)
-
-			return res.send({
-				data: completedResult.eventRecords,
-				meta: { total: completedResult.eventCount, skip, take }
-			})
-		}
-
-		if (type === 'WITHDRAWAL_COMPLETED' && withdrawalRoot) {
-			const completedResult = await fetchAndMapStakerEvents(
-				'WITHDRAWAL_COMPLETED',
-				completedFilterQuery,
-				withTokenData,
-				withEthValue,
-				skip,
-				take
-			)
-			return res.send({
-				data: completedResult.eventRecords,
-				meta: { total: completedResult.eventCount, skip, take }
-			})
 		}
 
 		const queuedResult = await fetchAndMapStakerEvents(
@@ -722,6 +693,20 @@ export async function getStakerWithdrawalEvents(req: Request, res: Response) {
 			skip,
 			take
 		)
+
+		if (txHash) {
+			if (queuedResult.eventRecords.length > 0 && type !== 'WITHDRAWAL_COMPLETED') {
+				return res.send({
+					data: queuedResult.eventRecords,
+					meta: { total: queuedResult.eventCount, skip, take }
+				})
+			}
+
+			return res.send({
+				data: [],
+				meta: { total: 0, skip, take }
+			})
+		}
 
 		if (type === 'WITHDRAWAL_QUEUED') {
 			return res.send({

--- a/packages/api/src/routes/stakers/stakerController.ts
+++ b/packages/api/src/routes/stakers/stakerController.ts
@@ -699,7 +699,7 @@ export async function getStakerWithdrawalEvents(req: Request, res: Response) {
 			})
 		}
 
-		if (type === 'WITHDRAWAL_COMPLETED' && (withdrawalRoot || txHash)) {
+		if (type === 'WITHDRAWAL_COMPLETED' && withdrawalRoot) {
 			const completedResult = await fetchAndMapStakerEvents(
 				'WITHDRAWAL_COMPLETED',
 				completedFilterQuery,
@@ -714,22 +714,6 @@ export async function getStakerWithdrawalEvents(req: Request, res: Response) {
 			})
 		}
 
-		if (type === 'WITHDRAWAL_QUEUED') {
-			const queuedResult = await fetchAndMapStakerEvents(
-				'WITHDRAWAL_QUEUED',
-				queuedFilterQuery,
-				withTokenData,
-				withEthValue,
-				skip,
-				take
-			)
-			return res.send({
-				data: queuedResult.eventRecords,
-				meta: { total: queuedResult.eventCount, skip, take }
-			})
-		}
-
-		// Default case: Fetch queued events, then use withdrawalRoots for completed events
 		const queuedResult = await fetchAndMapStakerEvents(
 			'WITHDRAWAL_QUEUED',
 			queuedFilterQuery,
@@ -738,6 +722,15 @@ export async function getStakerWithdrawalEvents(req: Request, res: Response) {
 			skip,
 			take
 		)
+
+		if (type === 'WITHDRAWAL_QUEUED') {
+			return res.send({
+				data: queuedResult.eventRecords,
+				meta: { total: queuedResult.eventCount, skip, take }
+			})
+		}
+
+		// Default case: Fetch queued events, then use withdrawalRoots for completed events
 		queuedEvents = queuedResult.eventRecords
 
 		const withdrawalRoots = queuedEvents

--- a/packages/api/src/routes/stakers/stakerRoutes.ts
+++ b/packages/api/src/routes/stakers/stakerRoutes.ts
@@ -6,7 +6,10 @@ import {
 	getStakerWithdrawalsCompleted,
 	getStakerWithdrawalsQueued,
 	getStakerWithdrawalsWithdrawable,
-	getStakerDeposits
+	getStakerDeposits,
+	getStakerDelegationEvents,
+	getStakerDepositEvents,
+	getStakerWithdrawalEvents
 } from './stakerController'
 
 const router = express.Router()
@@ -21,5 +24,9 @@ router.get('/:address/withdrawals/queued_withdrawable', getStakerWithdrawalsWith
 router.get('/:address/withdrawals/completed', getStakerWithdrawalsCompleted)
 
 router.get('/:address/deposits', getStakerDeposits)
+
+router.get('/:address/events/delegation', getStakerDelegationEvents)
+router.get('/:address/events/deposit', getStakerDepositEvents)
+router.get('/:address/events/withdrawal', getStakerWithdrawalEvents)
 
 export default router

--- a/packages/api/src/schema/zod/schemas/stakerEvents.ts
+++ b/packages/api/src/schema/zod/schemas/stakerEvents.ts
@@ -1,0 +1,184 @@
+import z from '../'
+import { getValidatedDates, validateDateRange } from '../../../utils/dateUtils'
+import { WithTokenDataQuerySchema, WithEthValueQuerySchema } from './withTokenDataQuery'
+
+const isoRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+const yyyymmddRegex = /^\d{4}-\d{2}-\d{2}$/
+
+const BaseStakerEventQuerySchema = z
+	.object({
+		txHash: z
+			.string()
+			.regex(/^0x([A-Fa-f0-9]{64})$/, 'Invalid transaction hash')
+			.optional()
+			.describe('The transaction hash associated with the event'),
+
+		startAt: z
+			.string()
+			.optional()
+			.refine(
+				(val) =>
+					!val ||
+					((isoRegex.test(val) || yyyymmddRegex.test(val)) &&
+						!Number.isNaN(new Date(val).getTime())),
+				{
+					message: 'Invalid date format for startAt. Use YYYY-MM-DD or ISO 8601 format.'
+				}
+			)
+			.default('')
+			.describe('Start date in ISO string format'),
+
+		endAt: z
+			.string()
+			.optional()
+			.refine(
+				(val) =>
+					!val ||
+					((isoRegex.test(val) || yyyymmddRegex.test(val)) &&
+						!Number.isNaN(new Date(val).getTime())),
+				{
+					message: 'Invalid date format for endAt. Use YYYY-MM-DD or ISO 8601 format.'
+				}
+			)
+			.default('')
+			.describe('End date in ISO string format')
+	})
+	.merge(WithTokenDataQuerySchema)
+	.merge(WithEthValueQuerySchema)
+
+function refineStakerEventQuerySchema(schema: z.ZodRawShape) {
+	return BaseStakerEventQuerySchema.extend(schema)
+		.refine(
+			(data) => {
+				if (data.withEthValue && !data.withTokenData) {
+					return false
+				}
+				return true
+			},
+			{
+				message: "'withEthValue' requires 'withTokenData' to be enabled.",
+				path: ['withEthValue']
+			}
+		)
+		.refine(
+			(data) => {
+				if (data.startAt && data.endAt) {
+					return new Date(data.endAt).getTime() >= new Date(data.startAt).getTime()
+				}
+				return true
+			},
+			{
+				message: 'endAt must be after startAt',
+				path: ['endAt']
+			}
+		)
+		.refine(
+			(data) => {
+				try {
+					const dates = getValidatedDates(data.startAt, data.endAt)
+					Object.assign(data, dates)
+
+					return validateDateRange(data.startAt, data.endAt)
+				} catch {
+					return false
+				}
+			},
+			{
+				message: 'Duration between startAt and endAt exceeds the allowed limit of 30 days.',
+				path: ['startAt', 'endAt']
+			}
+		)
+}
+
+// Schema for Delegation events
+export const DelegationStakerEventQuerySchema = refineStakerEventQuerySchema({
+	type: z
+		.enum(['SHARES_INCREASED', 'SHARES_DECREASED', 'DELEGATION', 'UNDELEGATION'])
+		.optional()
+		.describe('The type of the delegation event'),
+	operatorAddress: z
+		.string()
+		.regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid Ethereum address')
+		.optional()
+		.describe('The address of the operator'),
+	strategyAddress: z
+		.string()
+		.regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid Ethereum address')
+		.optional()
+		.describe('The contract address of the restaking strategy')
+}).refine(
+	(data) => {
+		if ((data.type === 'DELEGATION' || data.type === 'UNDELEGATION') && data.strategyAddress) {
+			return false
+		}
+		return true
+	},
+	{
+		message: 'strategyAddress filter is not supported for DELEGATION or UNDELEGATION event types.',
+		path: ['strategyAddress']
+	}
+)
+
+// Schema for Deposit events
+export const DepositStakerEventQuerySchema = refineStakerEventQuerySchema({
+	type: z.literal('DEPOSIT').optional().describe('The type of the deposit event'),
+	tokenAddress: z
+		.string()
+		.regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid token address')
+		.optional()
+		.describe('The address of the token involved in the event'),
+	strategyAddress: z
+		.string()
+		.regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid strategy address')
+		.optional()
+		.describe('The strategy address for filtering')
+})
+
+// Schema for Withdrawal events
+export const WithdrawalStakerEventQuerySchema = refineStakerEventQuerySchema({
+	type: z
+		.enum(['WITHDRAWAL_QUEUED', 'WITHDRAWAL_COMPLETED'])
+		.optional()
+		.describe('The type of the withdrawal event'),
+	withdrawalRoot: z
+		.string()
+		.regex(/^0x[a-fA-F0-9]{64}$/, 'Invalid withdrawal root format')
+		.optional()
+		.describe('The withdrawal root associated with the event'),
+	delegatedTo: z
+		.string()
+		.regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid Ethereum address')
+		.optional()
+		.describe('The address to which funds were delegated'),
+	withdrawer: z
+		.string()
+		.regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid Ethereum address')
+		.optional()
+		.describe('The address of the withdrawer')
+})
+	.refine(
+		(data) => {
+			if (data.type === 'WITHDRAWAL_COMPLETED' && (data.delegatedTo || data.withdrawer)) {
+				return false
+			}
+			return true
+		},
+		{
+			message:
+				"'delegatedTo' and 'withdrawer' filters are not supported for WITHDRAWAL_QUEUED event types.",
+			path: ['delegatedTo', 'withdrawer']
+		}
+	)
+	.refine(
+		(data) => {
+			if (data.type === 'WITHDRAWAL_COMPLETED' && (data.withTokenData || data.withEthValue)) {
+				return false
+			}
+			return true
+		},
+		{
+			message:
+				"'withTokenData' and 'withEthValue' filters are not supported for WITHDRAWAL_QUEUED event types.",
+			path: ['withTokenData', 'withEthValue']
+		}
+	)

--- a/packages/api/src/schema/zod/schemas/stakerEvents.ts
+++ b/packages/api/src/schema/zod/schemas/stakerEvents.ts
@@ -124,7 +124,6 @@ export const DelegationStakerEventQuerySchema = refineStakerEventQuerySchema({
 
 // Schema for Deposit events
 export const DepositStakerEventQuerySchema = refineStakerEventQuerySchema({
-	type: z.literal('DEPOSIT').optional().describe('The type of the deposit event'),
 	tokenAddress: z
 		.string()
 		.regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid token address')

--- a/packages/api/src/schema/zod/schemas/stakerEvents.ts
+++ b/packages/api/src/schema/zod/schemas/stakerEvents.ts
@@ -108,13 +108,16 @@ export const DelegationStakerEventQuerySchema = refineStakerEventQuerySchema({
 		.describe('The contract address of the restaking strategy')
 }).refine(
 	(data) => {
-		if ((data.type === 'DELEGATION' || data.type === 'UNDELEGATION') && data.strategyAddress) {
-			return false
+		if (data.type === 'DELEGATION' || data.type === 'UNDELEGATION') {
+			if (data.strategyAddress || data.withTokenData || data.withEthValue) {
+				return false
+			}
 		}
 		return true
 	},
 	{
-		message: 'strategyAddress filter is not supported for DELEGATION or UNDELEGATION event types.',
+		message:
+			"'strategyAddress','withTokenData', and 'withEthValue' filters are not supported for DELEGATION or UNDELEGATION  event types.",
 		path: ['strategyAddress']
 	}
 )
@@ -155,30 +158,18 @@ export const WithdrawalStakerEventQuerySchema = refineStakerEventQuerySchema({
 		.regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid Ethereum address')
 		.optional()
 		.describe('The address of the withdrawer')
-})
-	.refine(
-		(data) => {
-			if (data.type === 'WITHDRAWAL_COMPLETED' && (data.delegatedTo || data.withdrawer)) {
+}).refine(
+	(data) => {
+		if (data.type === 'WITHDRAWAL_COMPLETED') {
+			if (data.delegatedTo || data.withdrawer || data.withTokenData || data.withEthValue) {
 				return false
 			}
-			return true
-		},
-		{
-			message:
-				"'delegatedTo' and 'withdrawer' filters are not supported for WITHDRAWAL_QUEUED event types.",
-			path: ['delegatedTo', 'withdrawer']
 		}
-	)
-	.refine(
-		(data) => {
-			if (data.type === 'WITHDRAWAL_COMPLETED' && (data.withTokenData || data.withEthValue)) {
-				return false
-			}
-			return true
-		},
-		{
-			message:
-				"'withTokenData' and 'withEthValue' filters are not supported for WITHDRAWAL_QUEUED event types.",
-			path: ['withTokenData', 'withEthValue']
-		}
-	)
+		return true
+	},
+	{
+		message:
+			"'delegatedTo', 'withdrawer', 'withTokenData', and 'withEthValue' filters are not supported for WITHDRAWAL_COMPLETED event types.",
+		path: ['delegatedTo', 'withdrawer', 'withTokenData', 'withEthValue']
+	}
+)

--- a/packages/api/src/utils/dateUtils.ts
+++ b/packages/api/src/utils/dateUtils.ts
@@ -1,0 +1,53 @@
+const maxDuration = 30 * 24 * 60 * 60 * 1000 // 30 days
+const defaultDuration = 7 * 24 * 60 * 60 * 1000 // 7 days
+
+/**
+ * Validates that the given time range doesn't exceed the max allowed duration.
+ *
+ * @param startAt
+ * @param endAt
+ * @returns
+ */
+export const validateDateRange = (startAt: string, endAt: string) => {
+	const start = new Date(startAt)
+	const end = new Date(endAt || new Date())
+	const durationMs = end.getTime() - start.getTime()
+	return durationMs <= maxDuration
+}
+
+/**
+ * Utility to get default dates if not provided.
+ * Default to last 7 days
+ *
+ * @param startAt
+ * @param endAt
+ * @returns
+ */
+export const getValidatedDates = (startAt?: string, endAt?: string) => {
+	const now = new Date()
+
+	if (!startAt && !endAt) {
+		return {
+			startAt: new Date(now.getTime() - defaultDuration).toISOString(),
+			endAt: null
+		}
+	}
+
+	if (startAt && !endAt) {
+		const start = new Date(startAt)
+		return {
+			startAt,
+			endAt: new Date(Math.min(start.getTime() + defaultDuration, now.getTime())).toISOString()
+		}
+	}
+
+	if (!startAt && endAt) {
+		const end = new Date(endAt)
+		return {
+			startAt: new Date(end.getTime() - defaultDuration).toISOString(),
+			endAt
+		}
+	}
+
+	return { startAt, endAt }
+}


### PR DESCRIPTION
### Staker Event API V1

**Introduction**

This API will cover the following 6 events 

- EventLogs_StakerDelegated
- EventLogs_StakerUndelegated
- EventLogs_OperatorSharesIncreased
- EventLogs_OperatorSharesDecreased
- EventLogs_Deposit
- EventLogs_WithdrawalQueued

with event types
- DELEGATION
- UNDELEGATION
- SHARES_INCREASED
- SHARES_DECREASED
- DEPOSIT
- WITHDRAWAL_QUEUED
- WITHDRAWAL_COMPLETED

divided into 3 endpoints as follows 

### API endpoints

1. `/stakers/[address]/events/delegation`
(This is similar to the operator event delegation endpoint except this one is for stakers)

Event Types

- DELEGATION
- UNDELEGATION
- SHARES_INCREASED
- SHARES_DECREASED

Response
```
{
  type: string // name of the event
  tx: string // transaction hash
  blockNumber: number // block number of the tx
  blockTime: Date // blocktime of the tx
  args: {
    operator: string
    strategy?: string
    shares?: number
  },
   underlyingToken?: string
   underlyingValue?: number
   ethValue?: number
}
```

Supported Filters

- event type
- transaction hash
- start date for blockTime
- end date for blockTime
- operator address
- strategy address (for shares increased, shares decreased)
- withTokenData (when enabled, returns underlyingToken and underlyingValue)
- withEthValue (when enabled, returns ethValue)

2. `/stakers/[address]/events/deposit`

Event Type
DEPOSIT

Response
```
{
  type: string // name of the event
  tx: string // transaction hash
  blockNumber: number // block number of the tx
  blockTime: Date // blocktime of the tx
  args: {
    token: string
    strategy: string
    shares: number
  },
   underlyingToken?: string
   underlyingValue?: number
   ethValue?: number
}
```

Supported Filters
- transaction hash
- start date for blockTime
- end date for blockTime
- token address
- strategy address
- withTokenData (when enabled, returns underlyingToken and underlyingValue)
- withEthValue (when enabled, returns ethValue)

3.`/stakers/[address]/events/withdrawal`

Event Types
WITHDRAWAL_QUEUED
WITHDRAWAL_COMPLETED

Response
```
{
  type: string // name of the event
  tx: string // transaction hash
  blockNumber: number // block number of the tx
  blockTime: Date // blocktime of the tx
  args: {
    withdrawalRoot: string
    delegatedTo?: string
    withdrawer?: string
    nonce?: number
    startBlock?: number
    strategies?: [
	{
	    strategy: string
            shares: string
            underlyingToken?: string
            underlyingValue?: number
            ethValue?: number
	}	
    ]
  }
}
```

Supported Filters

- type
- transaction hash
- withdrawalRoot
- start date for blockTime
- end date for blockTime
- delegatedTo (for WITHDRAWAL_QUEUED)
- withdrawer (for WITHDRAWAL_QUEUED)
- withTokenData (for WITHDRAWAL_QUEUED)(when enabled, returns underlyingToken and underlyingValue)
- withEthValue (for WITHDRAWAL_QUEUED)(when enabled, returns ethValue)
