### PR TITLE
[API] - Option to return count of Stakers whose shares > 0 

### DIFF
--- a/packages/api/src/schema/zod/schemas/activeQuery.ts
+++ b/packages/api/src/schema/zod/schemas/activeQuery.ts
@@ -1,0 +1,9 @@
+import z from '../'
+
+export const ActiveQuerySchema = z.object({
+	active: z
+		.enum(['true', 'false'])
+		.optional()
+		.describe('Fetch only those stakers with shares > 0')
+		.openapi({ example: 'true' })
+})


### PR DESCRIPTION
Added new flag `active`to return stakers who have at least 1 strategy with shares > 0 

```
GET /stakers?active=true
```