### PR TITLE
Fix: Use settings key to sync reward snapshots

### DIFF
--- a/packages/seeder/src/events/seedLogsRewardsSubmissions.ts
+++ b/packages/seeder/src/events/seedLogsRewardsSubmissions.ts
@@ -57,7 +57,7 @@ export async function seedLogsAVSRewardsSubmission(toBlock?: bigint, fromBlock?:
 				if (log.args.rewardsSubmission?.strategiesAndMultipliers) {
 					for (const strategyAndMultiplier of log.args.rewardsSubmission.strategiesAndMultipliers) {
 						strategies.push(strategyAndMultiplier.strategy.toLowerCase())
-						multipliers.push(String(strategyAndMultiplier.multiplier.toString()))
+						multipliers.push(strategyAndMultiplier.multiplier.toString())
 					}
 
 					logsAvsRewardsSubmissions.push({
@@ -103,6 +103,6 @@ export async function seedLogsAVSRewardsSubmission(toBlock?: bigint, fromBlock?:
 				dbTransactions,
 				`[Logs] AVS Rewards Submission from: ${fromBlock} to: ${toBlock} size: ${seedLength}`
 			)
-		} catch (error) {}
+		} catch {}
 	})
 }

--- a/packages/seeder/src/monitors/avsApy.ts
+++ b/packages/seeder/src/monitors/avsApy.ts
@@ -25,6 +25,11 @@ export async function monitorAvsApy() {
 		try {
 			// Fetch totalStakers, totalOperators & rewards data for all avs in this iteration
 			const avsMetrics = await prismaClient.avs.findMany({
+				where: {
+					rewardSubmissions: {
+						some: {}
+					}
+				},
 				include: {
 					operators: {
 						where: { isActive: true },


### PR DESCRIPTION
- In `seedStakerRewardSnapshots` now we use a key on the Settings table to store the last synced timestamp. Previously, we incorrectly assumed that all snapshots would have the same date and just made a prisma call to the `StakerRewardSnapshot` table to find the latest timestamp. However, the table actually stores the latest timestamp for a given record rather than the latest timestamp of the snapshot requested from the EL bucket.

- Additionally, a minor optimization is made to the AVS APY monitor prisma call to consider only those AVSs that have reward submissions 
