### PR TITLE
[Feat] - Server Auth v2

### DIFF
--- a/packages/api/src/utils/authMiddleware.ts
+++ b/packages/api/src/utils/authMiddleware.ts
@@ -151,27 +151,6 @@ export const rateLimiter = (req: Request, res: Response, next: NextFunction) => 
 
 	// Apply rate limiting
 	const limiter = rateLimiters[accessLevel]
-
-	// Increment `requestsStore` for successful requests
-	const originalEnd = res.end
-
-	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
-	res.end = function (chunk?: any, encoding?: any, cb?: any) {
-		try {
-			if (res.statusCode >= 200 && res.statusCode < 300) {
-				const apiToken = req.header('X-API-Token')
-				if (apiToken) {
-					const key = `apiToken:${apiToken}:newRequests`
-					const currentCalls: number = requestsStore.get(key) || 0
-					requestsStore.set(key, currentCalls + 1)
-				}
-			}
-		} catch {}
-
-		res.end = originalEnd
-		return originalEnd.call(this, chunk, encoding, cb)
-	}
-
 	return limiter(req, res, next)
 }
 

--- a/packages/api/src/utils/request.ts
+++ b/packages/api/src/utils/request.ts
@@ -4,6 +4,7 @@ declare global {
 	namespace Express {
 		interface Request {
 			accessLevel?: number
+			cost?: number
 		}
 	}
 }

--- a/packages/api/src/utils/routeCost.ts
+++ b/packages/api/src/utils/routeCost.ts
@@ -1,0 +1,15 @@
+import type { NextFunction, Request, Response } from 'express'
+
+/**
+ * Middleware function to be used when defining API routes and pointing them to their internal functions
+ * If not set, cost calculator after route completion will consider cost as 1
+ *
+ * @param cost
+ * @returns
+ */
+export function setRouteCost(cost: number) {
+	return (req: Request, _res: Response, next: NextFunction) => {
+		req.cost = cost
+		next()
+	}
+}


### PR DESCRIPTION
- Unauthenticated callers (invalid or non-existent API token) receive a 401 response. Callers must set `X-API-Token` (case insensitive) header along with a valid token generated from EE dev portal in order to access EE API.

- Monthly limits & per-minute rate limits are now imposed. The user attains an `accessLevel` basis the plan they have signed up for on the EE dev portal.

```
const PLANS: Record<number, Plan> = {
	0: {
		name: 'Unauthenticated'
	},
	1: {
		name: 'Free',
		requestsPerMin: 30,
		requestsPerMonth: 1_000
	},
	2: {
		name: 'Basic',
		requestsPerMin: 1_000,
		requestsPerMonth: 10_000
	},
	999: {
		name: 'Admin'
	}
}
```

- Each route can explicitly define its `cost` (which defaults to 1 if not set). In order to price a route, define it in the API route config like this:

```
/src/routes/metrics/metricRoutes.ts


import { setRouteCost } from '../../utils/routeCost'

router.get('/', routeCache.cacheSeconds(120), setRouteCost(2), getMetrics)
```
