### PR TITLE
Fix: Switch from theoretical to actual maxApy for a given Operator/AVS combo

### DIFF
--- a/packages/api/src/routes/operators/operatorController.ts
+++ b/packages/api/src/routes/operators/operatorController.ts
@@ -595,6 +595,14 @@ async function calculateOperatorApy(operator: any) {
 
 			// Iterate through each strategy and calculate all its rewards
 			for (const strategyAddress of avs.avs.restakeableStrategies) {
+				// Omit strategy where the Operator doesn't have shares
+				if (
+					!operator.shares.find(
+						(share) => share.strategyAddress.toLowerCase() === strategyAddress.toLowerCase()
+					)
+				)
+					continue
+
 				const strategyTvl = tvlStrategiesEth[strategyAddress.toLowerCase()] || 0
 				if (strategyTvl === 0) continue
 
@@ -677,7 +685,7 @@ async function calculateOperatorApy(operator: any) {
 
 			avsApyMap.set(avs.avs.address, {
 				avsAddress: avs.avs.address,
-				maxApy: avs.avs.maxApy,
+				maxApy: Math.max(...Array.from(strategyApyMap.values()).map((data) => data.apy)),
 				strategyApys: Array.from(strategyApyMap.entries()).map(([strategyAddress, data]) => ({
 					strategyAddress,
 					apy: data.apy,


### PR DESCRIPTION
In the response of `GET /operators/:address?withRewards=true`, the `maxApy` for a given AVS is its theoretical value rather than actual.

For eg: if the Operator is delegated to ARPA, theoretically its max APY is 50% if it chooses to stake ARPA. However if the Operator doesn’t currently stake ARPA, our API still returned 50%.

With this update, our API considers only those strategies where the Operator participates, hence switching to actual `maxApy` value.