### PR TITLE
Slashing Upgrade for Withdrawal Endpoints 

### DIFF
--- a/packages/api/src/routes/stakers/stakerController.ts
+++ b/packages/api/src/routes/stakers/stakerController.ts
@@ -7,6 +7,7 @@ import { WithTvlQuerySchema } from '../../schema/zod/schemas/withTvlQuery'
 import { getViemClient } from '../../viem/viemClient'
 import {
 	getStrategiesWithShareUnderlying,
+	processWithdrawals,
 	sharesToTVL,
 	sharesToTVLStrategies
 } from '../../utils/strategyShares'
@@ -224,22 +225,7 @@ export async function getStakerWithdrawals(req: Request, res: Response) {
 			orderBy: { createdAtBlock: 'desc' }
 		})
 
-		const data = withdrawalRecords.map((withdrawal) => {
-			const shares = withdrawal.shares.map((s, i) => ({
-				strategyAddress: withdrawal.strategies[i],
-				shares: s
-			}))
-
-			return {
-				...withdrawal,
-				shares,
-				strategies: undefined,
-				completedWithdrawal: undefined,
-				isCompleted: !!withdrawal.completedWithdrawal,
-				updatedAt: withdrawal.completedWithdrawal?.createdAt || withdrawal.createdAt,
-				updatedAtBlock: withdrawal.completedWithdrawal?.createdAtBlock || withdrawal.createdAtBlock
-			}
-		})
+		const data = await processWithdrawals(withdrawalRecords)
 
 		res.send({
 			data,
@@ -282,18 +268,7 @@ export async function getStakerWithdrawalsQueued(req: Request, res: Response) {
 			orderBy: { createdAtBlock: 'desc' }
 		})
 
-		const data = withdrawalRecords.map((withdrawal) => {
-			const shares = withdrawal.shares.map((s, i) => ({
-				strategyAddress: withdrawal.strategies[i],
-				shares: s
-			}))
-
-			return {
-				...withdrawal,
-				shares,
-				strategies: undefined
-			}
-		})
+		const data = await processWithdrawals(withdrawalRecords)
 
 		res.send({
 			data,
@@ -348,18 +323,7 @@ export async function getStakerWithdrawalsWithdrawable(req: Request, res: Respon
 			orderBy: { createdAtBlock: 'desc' }
 		})
 
-		const data = withdrawalRecords.map((withdrawal) => {
-			const shares = withdrawal.shares.map((s, i) => ({
-				strategyAddress: withdrawal.strategies[i],
-				shares: s
-			}))
-
-			return {
-				...withdrawal,
-				shares,
-				strategies: undefined
-			}
-		})
+		const data = await processWithdrawals(withdrawalRecords)
 
 		res.send({
 			data,
@@ -410,21 +374,7 @@ export async function getStakerWithdrawalsCompleted(req: Request, res: Response)
 			orderBy: { createdAtBlock: 'desc' }
 		})
 
-		const data = withdrawalRecords.map((withdrawal) => {
-			const shares = withdrawal.shares.map((s, i) => ({
-				strategyAddress: withdrawal.strategies[i],
-				shares: s
-			}))
-
-			return {
-				...withdrawal,
-				shares,
-				strategies: undefined,
-				completedWithdrawal: undefined,
-				updatedAt: withdrawal.completedWithdrawal?.createdAt || withdrawal.createdAt,
-				updatedAtBlock: withdrawal.completedWithdrawal?.createdAtBlock || withdrawal.createdAtBlock
-			}
-		})
+		const data = await processWithdrawals(withdrawalRecords)
 
 		res.send({
 			data,

--- a/packages/prisma/migrations/20250203114725_slashing_upgrade/migration.sql
+++ b/packages/prisma/migrations/20250203114725_slashing_upgrade/migration.sql
@@ -1,3 +1,12 @@
+/*
+  Warnings:
+
+  - Added the required column `beaconChainSlashingFactor` to the `Pod` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Pod" ADD COLUMN     "beaconChainSlashingFactor" BIGINT NOT NULL;
+
 -- AlterTable
 ALTER TABLE "WithdrawalQueued" ADD COLUMN     "isSlashable" BOOLEAN NOT NULL DEFAULT false,
 ADD COLUMN     "sharesToWithdraw" TEXT[];
@@ -205,6 +214,21 @@ CREATE TABLE "EventLogs_StrategyRemovedFromOperatorSet" (
     CONSTRAINT "EventLogs_StrategyRemovedFromOperatorSet_pkey" PRIMARY KEY ("transactionHash","transactionIndex")
 );
 
+-- CreateTable
+CREATE TABLE "EventLogs_BeaconChainSlashingFactorDecreased" (
+    "address" TEXT NOT NULL,
+    "transactionHash" TEXT NOT NULL,
+    "transactionIndex" INTEGER NOT NULL,
+    "blockNumber" BIGINT NOT NULL,
+    "blockHash" TEXT NOT NULL,
+    "blockTime" TIMESTAMP(3) NOT NULL,
+    "staker" TEXT NOT NULL,
+    "prevBeaconChainSlashingFactor" BIGINT NOT NULL,
+    "newBeaconChainSlashingFactor" BIGINT NOT NULL,
+
+    CONSTRAINT "EventLogs_BeaconChainSlashingFactorDecreased_pkey" PRIMARY KEY ("transactionHash","transactionIndex")
+);
+
 -- CreateIndex
 CREATE INDEX "EventLogs_SlashingWithdrawalQueued_withdrawalRoot_idx" ON "EventLogs_SlashingWithdrawalQueued"("withdrawalRoot");
 
@@ -264,3 +288,9 @@ CREATE INDEX "EventLogs_StrategyRemovedFromOperatorSet_avs_strategy_idx" ON "Eve
 
 -- CreateIndex
 CREATE INDEX "EventLogs_StrategyRemovedFromOperatorSet_blockNumber_idx" ON "EventLogs_StrategyRemovedFromOperatorSet"("blockNumber");
+
+-- CreateIndex
+CREATE INDEX "EventLogs_BeaconChainSlashingFactorDecreased_staker_idx" ON "EventLogs_BeaconChainSlashingFactorDecreased"("staker");
+
+-- CreateIndex
+CREATE INDEX "EventLogs_BeaconChainSlashingFactorDecreased_blockNumber_idx" ON "EventLogs_BeaconChainSlashingFactorDecreased"("blockNumber");

--- a/packages/prisma/migrations/20250207094520_slashing_upgrade/migration.sql
+++ b/packages/prisma/migrations/20250207094520_slashing_upgrade/migration.sql
@@ -1,11 +1,5 @@
-/*
-  Warnings:
-
-  - Added the required column `beaconChainSlashingFactor` to the `Pod` table without a default value. This is not possible if the table is not empty.
-
-*/
 -- AlterTable
-ALTER TABLE "Pod" ADD COLUMN     "beaconChainSlashingFactor" BIGINT NOT NULL;
+ALTER TABLE "Pod" ADD COLUMN     "beaconChainSlashingFactor" TEXT NOT NULL DEFAULT '1000000000000000000';
 
 -- AlterTable
 ALTER TABLE "WithdrawalQueued" ADD COLUMN     "isSlashable" BOOLEAN NOT NULL DEFAULT false,
@@ -72,7 +66,7 @@ CREATE TABLE "EventLogs_AllocationUpdated" (
     "avs" TEXT NOT NULL,
     "operatorSetId" BIGINT NOT NULL,
     "strategy" TEXT NOT NULL,
-    "magnitude" BIGINT NOT NULL,
+    "magnitude" TEXT NOT NULL,
     "effectBlock" BIGINT NOT NULL,
 
     CONSTRAINT "EventLogs_AllocationUpdated_pkey" PRIMARY KEY ("transactionHash","transactionIndex")
@@ -88,7 +82,7 @@ CREATE TABLE "EventLogs_EncumberedMagnitudeUpdated" (
     "blockTime" TIMESTAMP(3) NOT NULL,
     "operator" TEXT NOT NULL,
     "strategy" TEXT NOT NULL,
-    "encumberedMagnitude" BIGINT NOT NULL,
+    "encumberedMagnitude" TEXT NOT NULL,
 
     CONSTRAINT "EventLogs_EncumberedMagnitudeUpdated_pkey" PRIMARY KEY ("transactionHash","transactionIndex")
 );
@@ -103,7 +97,7 @@ CREATE TABLE "EventLogs_MaxMagnitudeUpdated" (
     "blockTime" TIMESTAMP(3) NOT NULL,
     "operator" TEXT NOT NULL,
     "strategy" TEXT NOT NULL,
-    "maxMagnitude" BIGINT NOT NULL,
+    "maxMagnitude" TEXT NOT NULL,
 
     CONSTRAINT "EventLogs_MaxMagnitudeUpdated_pkey" PRIMARY KEY ("transactionHash","transactionIndex")
 );
@@ -223,8 +217,8 @@ CREATE TABLE "EventLogs_BeaconChainSlashingFactorDecreased" (
     "blockHash" TEXT NOT NULL,
     "blockTime" TIMESTAMP(3) NOT NULL,
     "staker" TEXT NOT NULL,
-    "prevBeaconChainSlashingFactor" BIGINT NOT NULL,
-    "newBeaconChainSlashingFactor" BIGINT NOT NULL,
+    "prevBeaconChainSlashingFactor" TEXT NOT NULL,
+    "newBeaconChainSlashingFactor" TEXT NOT NULL,
 
     CONSTRAINT "EventLogs_BeaconChainSlashingFactorDecreased_pkey" PRIMARY KEY ("transactionHash","transactionIndex")
 );

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -210,7 +210,7 @@ model Pod {
   address     String @id @unique
   owner       String
   blockNumber BigInt // @Deprecated, will remove in future release
-  beaconChainSlashingFactor BigInt
+  beaconChainSlashingFactor String @default("1000000000000000000")
 
   createdAtBlock BigInt   @default(0)
   updatedAtBlock BigInt   @default(0)
@@ -789,7 +789,7 @@ model EventLogs_AllocationUpdated {
   avs String
   operatorSetId BigInt
   strategy String
-  magnitude BigInt
+  magnitude String
   effectBlock BigInt
 
   @@id([transactionHash, transactionIndex])
@@ -807,7 +807,7 @@ model EventLogs_EncumberedMagnitudeUpdated {
 
   operator String
   strategy String
-  encumberedMagnitude BigInt
+  encumberedMagnitude String
 
   @@id([transactionHash, transactionIndex])
   @@index([blockNumber])
@@ -824,7 +824,7 @@ model EventLogs_MaxMagnitudeUpdated {
 
   operator String
   strategy String
-  maxMagnitude BigInt
+  maxMagnitude String
 
   @@id([transactionHash, transactionIndex])
   @@index([blockNumber])
@@ -965,8 +965,8 @@ model EventLogs_BeaconChainSlashingFactorDecreased {
   blockTime        DateTime
 
   staker String
-  prevBeaconChainSlashingFactor BigInt
-  newBeaconChainSlashingFactor  BigInt
+  prevBeaconChainSlashingFactor String
+  newBeaconChainSlashingFactor  String
 
   @@id([transactionHash, transactionIndex])
   @@index([staker])

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -210,6 +210,7 @@ model Pod {
   address     String @id @unique
   owner       String
   blockNumber BigInt // @Deprecated, will remove in future release
+  beaconChainSlashingFactor BigInt
 
   createdAtBlock BigInt   @default(0)
   updatedAtBlock BigInt   @default(0)
@@ -951,6 +952,24 @@ model EventLogs_StrategyRemovedFromOperatorSet {
 
   @@id([transactionHash, transactionIndex])
   @@index([avs,strategy])
+  @@index([blockNumber])
+}
+
+model EventLogs_BeaconChainSlashingFactorDecreased {
+  address String
+
+  transactionHash  String
+  transactionIndex Int
+  blockNumber      BigInt
+  blockHash        String
+  blockTime        DateTime
+
+  staker String
+  prevBeaconChainSlashingFactor BigInt
+  newBeaconChainSlashingFactor  BigInt
+
+  @@id([transactionHash, transactionIndex])
+  @@index([staker])
   @@index([blockNumber])
 }
 

--- a/packages/seeder/src/events/seedLogsAllocationUpdated.ts
+++ b/packages/seeder/src/events/seedLogsAllocationUpdated.ts
@@ -59,7 +59,7 @@ export async function seedLogsAllocationUpdated(toBlock?: bigint, fromBlock?: bi
 					avs: String(log.args.operatorSet?.avs),
 					operatorSetId: BigInt(log.args.operatorSet?.id || 0),
 					strategy: String(log.args.strategy),
-					magnitude: BigInt(log.args.magnitude || 0),
+					magnitude: String(log.args.magnitude),
 					effectBlock: BigInt(log.args.effectBlock || 0)
 				})
 			}

--- a/packages/seeder/src/events/seedLogsBeaconChainSlashingFactorDecreased.ts
+++ b/packages/seeder/src/events/seedLogsBeaconChainSlashingFactorDecreased.ts
@@ -54,8 +54,8 @@ export async function seedLogsBeaconChainSlashingFactor(toBlock?: bigint, fromBl
 					blockHash: log.blockHash,
 					blockTime: blockData.get(log.blockNumber) || new Date(0),
 					staker: String(log.args.staker),
-					prevBeaconChainSlashingFactor: BigInt(log.args.prevBeaconChainSlashingFactor || 0),
-					newBeaconChainSlashingFactor: BigInt(log.args.newBeaconChainSlashingFactor || 0)
+					prevBeaconChainSlashingFactor: String(log.args.prevBeaconChainSlashingFactor),
+					newBeaconChainSlashingFactor: String(log.args.newBeaconChainSlashingFactor)
 				})
 			}
 

--- a/packages/seeder/src/events/seedLogsBeaconChainSlashingFactorDecreased.ts
+++ b/packages/seeder/src/events/seedLogsBeaconChainSlashingFactorDecreased.ts
@@ -1,0 +1,89 @@
+import prisma from '@prisma/client'
+import { parseAbiItem } from 'viem'
+import { getEigenContracts } from '../data/address'
+import { getViemClient } from '../utils/viemClient'
+import {
+	bulkUpdateDbTransactions,
+	fetchLastSyncBlock,
+	getBlockDataFromDb,
+	loopThroughBlocks
+} from '../utils/seeder'
+import { getPrismaClient } from '../utils/prismaClient'
+
+const blockSyncKeyLogs = 'lastSyncedBlock_logs_beaconChainSlashingFactor'
+
+/**
+ * Seeder for `BeaconChainSlashingFactorDecreased` event logs
+ *
+ * @param toBlock
+ * @param fromBlock
+ */
+export async function seedLogsBeaconChainSlashingFactor(toBlock?: bigint, fromBlock?: bigint) {
+	const viemClient = getViemClient()
+	const prismaClient = getPrismaClient()
+
+	const firstBlock = fromBlock ? fromBlock : await fetchLastSyncBlock(blockSyncKeyLogs)
+	const lastBlock = toBlock ? toBlock : await viemClient.getBlockNumber()
+
+	// Loop through EVM logs
+	await loopThroughBlocks(firstBlock, lastBlock, async (fromBlock, toBlock) => {
+		const blockData = await getBlockDataFromDb(fromBlock, toBlock)
+
+		try {
+			const dbTransactions: any[] = []
+
+			const logsBeaconChainSlashingFactor: prisma.EventLogs_BeaconChainSlashingFactorDecreased[] =
+				[]
+
+			const logs = await viemClient.getLogs({
+				address: getEigenContracts().EigenPodManager,
+				event: parseAbiItem([
+					'event BeaconChainSlashingFactorDecreased(address staker, uint64 prevBeaconChainSlashingFactor, uint64 newBeaconChainSlashingFactor)'
+				]),
+				fromBlock,
+				toBlock
+			})
+
+			// Store event data in array
+			for (const log of logs) {
+				logsBeaconChainSlashingFactor.push({
+					address: log.address,
+					transactionHash: log.transactionHash,
+					transactionIndex: log.logIndex,
+					blockNumber: BigInt(log.blockNumber),
+					blockHash: log.blockHash,
+					blockTime: blockData.get(log.blockNumber) || new Date(0),
+					staker: String(log.args.staker),
+					prevBeaconChainSlashingFactor: BigInt(log.args.prevBeaconChainSlashingFactor || 0),
+					newBeaconChainSlashingFactor: BigInt(log.args.newBeaconChainSlashingFactor || 0)
+				})
+			}
+
+			dbTransactions.push(
+				prismaClient.eventLogs_BeaconChainSlashingFactorDecreased.createMany({
+					data: logsBeaconChainSlashingFactor,
+					skipDuplicates: true
+				})
+			)
+
+			// Store last synced block
+			dbTransactions.push(
+				prismaClient.settings.upsert({
+					where: { key: blockSyncKeyLogs },
+					update: { value: Number(toBlock) },
+					create: { key: blockSyncKeyLogs, value: Number(toBlock) }
+				})
+			)
+
+			// Update database
+			const seedLength = logsBeaconChainSlashingFactor.length
+
+			await bulkUpdateDbTransactions(
+				dbTransactions,
+				`[Logs] Beacon Chain Slashing Factor Decreased from: ${fromBlock} to: ${toBlock} size: ${seedLength}`
+			)
+		} catch (error) {
+			console.error('Error seeding BeaconChainSlashingFactorDecreased logs:', error)
+		}
+	})
+}

--- a/packages/seeder/src/events/seedLogsEncumberedMagnitudeUpdated.ts
+++ b/packages/seeder/src/events/seedLogsEncumberedMagnitudeUpdated.ts
@@ -56,7 +56,7 @@ export async function seedLogsEncumberedMagnitudeUpdated(toBlock?: bigint, fromB
 					blockTime: blockData.get(log.blockNumber) || new Date(0),
 					operator: String(log.args.operator),
 					strategy: String(log.args.strategy),
-					encumberedMagnitude: BigInt(log.args.encumberedMagnitude || 0)
+					encumberedMagnitude: String(log.args.encumberedMagnitude)
 				})
 			}
 

--- a/packages/seeder/src/events/seedLogsMaxMagnitudeUpdated.ts
+++ b/packages/seeder/src/events/seedLogsMaxMagnitudeUpdated.ts
@@ -56,7 +56,7 @@ export async function seedLogsMaxMagnitudeUpdated(toBlock?: bigint, fromBlock?: 
 					blockTime: blockData.get(log.blockNumber) || new Date(0),
 					operator: String(log.args.operator),
 					strategy: String(log.args.strategy),
-					maxMagnitude: BigInt(log.args.maxMagnitude || 0)
+					maxMagnitude: String(log.args.maxMagnitude)
 				})
 			}
 

--- a/packages/seeder/src/index.ts
+++ b/packages/seeder/src/index.ts
@@ -58,6 +58,8 @@ import { seedLogsStrategyAddedToOperatorSet } from './events/seedLogsStrategyAdd
 import { seedLogsStrategyRemovedFromOperatorSet } from './events/seedLogsStrategyRemovedFromOperatorSet'
 import { monitorAvsMetadata } from './monitors/avsMetadata'
 import { monitorOperatorMetadata } from './monitors/operatorMetadata'
+import { seedLogsBeaconChainSlashingFactor } from './events/seedLogsBeaconChainSlashingFactorDecreased'
+import { seedBeaconChainSlashingFactor } from './seedBeaconChainSlashingFactor'
 
 console.log('Initializing Seeder ...')
 
@@ -117,7 +119,8 @@ async function seedEigenData() {
 				seedLogsOperatorSetCreated(targetBlock),
 				seedLogsOperatorSlashed(targetBlock),
 				seedLogsStrategyAddedToOperatorSet(targetBlock),
-				seedLogsStrategyRemovedFromOperatorSet(targetBlock)
+				seedLogsStrategyRemovedFromOperatorSet(targetBlock),
+				seedLogsBeaconChainSlashingFactor(targetBlock)
 			])
 
 			await Promise.all([
@@ -142,6 +145,7 @@ async function seedEigenData() {
 				(async () => {
 					await seedPods()
 					await seedValidators()
+					await seedBeaconChainSlashingFactor()
 				})()
 			])
 

--- a/packages/seeder/src/seedBeaconChainSlashingFactor.ts
+++ b/packages/seeder/src/seedBeaconChainSlashingFactor.ts
@@ -1,0 +1,71 @@
+import { getPrismaClient } from './utils/prismaClient'
+import {
+	bulkUpdateDbTransactions,
+	fetchLastSyncBlock,
+	loopThroughBlocks,
+	saveLastSyncBlock
+} from './utils/seeder'
+
+const blockSyncKey = 'lastSyncedBlock_beaconChainSlashingFactor'
+const blockSyncKeyLogs = 'lastSyncedBlock_logs_beaconChainSlashingFactor'
+
+export async function seedBeaconChainSlashingFactor(toBlock?: bigint, fromBlock?: bigint) {
+	const prismaClient = getPrismaClient()
+
+	const firstBlock = fromBlock ? fromBlock : await fetchLastSyncBlock(blockSyncKey)
+	const lastBlock = toBlock ? toBlock : await fetchLastSyncBlock(blockSyncKeyLogs)
+
+	// Bail early if there is no new data
+	if (lastBlock - firstBlock <= 0) {
+		console.log(`[In Sync] [Data] BeaconChainSlashingFactor from: ${firstBlock} to: ${lastBlock}`)
+		return
+	}
+
+	await loopThroughBlocks(
+		firstBlock,
+		lastBlock,
+		async (fromBlock, toBlock) => {
+			const slashingFactorUpdates =
+				await prismaClient.eventLogs_BeaconChainSlashingFactorDecreased.findMany({
+					where: {
+						blockNumber: {
+							gt: fromBlock,
+							lte: toBlock
+						}
+					},
+					orderBy: { blockNumber: 'asc' }
+				})
+
+			// Prepare db transaction object
+			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+			const dbTransactions: any[] = []
+
+			for (const update of slashingFactorUpdates) {
+				// Find the Pod associated with this staker (since staker is Pod owner)
+				const pod = await prismaClient.pod.findFirst({
+					where: { owner: update.staker.toLowerCase() },
+					select: { address: true }
+				})
+
+				// If a pod is found, update its beaconChainSlashingFactor
+				if (pod) {
+					dbTransactions.push(
+						prismaClient.pod.update({
+							where: { address: pod.address },
+							data: { beaconChainSlashingFactor: update.newBeaconChainSlashingFactor }
+						})
+					)
+				}
+			}
+
+			await bulkUpdateDbTransactions(
+				dbTransactions,
+				`[Data] BeaconChainSlashingFactor from: ${fromBlock} to: ${toBlock} size: ${slashingFactorUpdates.length}`
+			)
+		},
+		10_000n
+	)
+
+	// Storing last synced block
+	await saveLastSyncBlock(blockSyncKey, lastBlock)
+}

--- a/packages/seeder/src/seedPods.ts
+++ b/packages/seeder/src/seedPods.ts
@@ -55,7 +55,7 @@ export async function seedPods(toBlock?: bigint, fromBlock?: bigint) {
 					address: podAddress,
 					owner: podOwner,
 					blockNumber,
-					beaconChainSlashingFactor: 1000000000000000000n,
+					beaconChainSlashingFactor: '1000000000000000000',
 					createdAtBlock: blockNumber,
 					updatedAtBlock: blockNumber,
 					createdAt: timestamp,

--- a/packages/seeder/src/seedPods.ts
+++ b/packages/seeder/src/seedPods.ts
@@ -55,6 +55,7 @@ export async function seedPods(toBlock?: bigint, fromBlock?: bigint) {
 					address: podAddress,
 					owner: podOwner,
 					blockNumber,
+					beaconChainSlashingFactor: 1000000000000000000n,
 					createdAtBlock: blockNumber,
 					updatedAtBlock: blockNumber,
 					createdAt: timestamp,

--- a/packages/seeder/src/seedSlashingWithdrawalsCompleted.ts
+++ b/packages/seeder/src/seedSlashingWithdrawalsCompleted.ts
@@ -112,7 +112,7 @@ export async function seedCompletedSlashingWithdrawals(toBlock?: bigint, fromBlo
 
 	await bulkUpdateDbTransactions(
 		dbTransactions,
-		`[Data] Completed Withdrawal from: ${firstBlock} to: ${lastBlock} size: ${completedWithdrawalList.length}`
+		`[Data] Completed Withdrawal (Slashing) from: ${firstBlock} to: ${lastBlock} size: ${completedWithdrawalList.length}`
 	)
 
 	// Storing last synced block

--- a/packages/seeder/src/seedSlashingWithdrawalsQueued.ts
+++ b/packages/seeder/src/seedSlashingWithdrawalsQueued.ts
@@ -87,7 +87,7 @@ export async function seedQueuedSlashingWithdrawals(toBlock?: bigint, fromBlock?
 
 	await bulkUpdateDbTransactions(
 		dbTransactions,
-		`[Data] Queued Withdrawal from: ${firstBlock} to: ${lastBlock} size: ${queuedWithdrawalList.length}`
+		`[Data] Queued Withdrawal (Slashing) from: ${firstBlock} to: ${lastBlock} size: ${queuedWithdrawalList.length}`
 	)
 
 	// // Storing last sycned block


### PR DESCRIPTION
This PR updates the following routes as a part of the slashing upgrade

Withdrawal

- /withdrawals
- /withdrawals/[withdrawalRoot]

Staker

- /staker/[address]/withdrawals
- /staker/[address]/withdrawals/queued
- /staker/[address]/withdrawals/queued_withdrawable
- /staker/[address]/withdrawals/completed

Now the routes will return the withdrawals post slashing as well and the shares structure will look like
```
"shares": [
                {
                    "strategyAddress": "0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0",
                    "shares": "32000000000000000000",
                    "sharesToWithdraw": "32000000000000000000"
                }
            ]
```

Thing to note here is that we are storing sharesToWithdraw at the time of queueing in our DB (model WithdrawalQueued)
but these sharesToWithdraw but in case a slashing happens between the withdrawal period, the sharesToWithdraw will change hence everywhere the value of sharesToWithdraw is being calculated using 

`scaledShares * maxMagnitude * beaconChainScalingFactor (only for beaconChain strategy)`

- Updated seedMetricsWithdrawal to accomodate slashing withdrawals

