### PR TITLE
[Feat] - Upgrade Avs Curated Metadata API

### DIFF
--- a/packages/api/src/routes/avs/avsController.ts
+++ b/packages/api/src/routes/avs/avsController.ts
@@ -756,6 +756,84 @@ export async function invalidateMetadata(req: Request, res: Response) {
 }
 
 /**
+ * Function for route /avs/:address/create-metadata
+ * Protected route to create a new curated metadata for a given AVS address
+ *
+ * @param req
+ * @param res
+ */
+export async function createMetadata(req: Request, res: Response) {
+	const paramCheck = EthereumAddressSchema.safeParse(req.params.address)
+	if (!paramCheck.success) {
+		return handleAndReturnErrorResponse(req, res, paramCheck.error)
+	}
+
+	const bodyCheck = UpdateMetadataSchema.safeParse(req.body)
+	if (!bodyCheck.success) {
+		return handleAndReturnErrorResponse(req, res, bodyCheck.error)
+	}
+
+	try {
+		const accessLevel = isAuthRequired() ? req.accessLevel || 0 : 999
+
+		if (accessLevel !== 999) {
+			throw new EigenExplorerApiError({ code: 'unauthorized', message: 'Unauthorized access.' })
+		}
+
+		const { address } = req.params
+		const metadataData = bodyCheck.data
+
+		const existingRecord = await prisma.avsCuratedMetadata.findUnique({
+			where: { avsAddress: address.toLowerCase() }
+		})
+
+		if (existingRecord) {
+			throw new EigenExplorerApiError({
+				code: 'bad_request',
+				message: 'Metadata for this AVS already exists.'
+			})
+		}
+
+		const avsExists = await prisma.avs.findUnique({
+			where: { address: address.toLowerCase() }
+		})
+
+		if (!avsExists) {
+			throw new EigenExplorerApiError({
+				code: 'not_found',
+				message: 'AVS not found.'
+			})
+		}
+
+		const createData = {
+			avsAddress: address.toLowerCase(),
+			metadataName: metadataData.metadataName || null,
+			metadataDescription: metadataData.metadataDescription || null,
+			metadataDiscord: metadataData.metadataDiscord || null,
+			metadataLogo: metadataData.metadataLogo || null,
+			metadataTelegram: metadataData.metadataTelegram || null,
+			metadataWebsite: metadataData.metadataWebsite || null,
+			metadataX: metadataData.metadataX || null,
+			metadataGithub: metadataData.metadataGithub || null,
+			metadataTokenAddress: metadataData.metadataTokenAddress || null,
+			additionalConfig: metadataData.additionalConfig || Prisma.Prisma.JsonNull,
+			tags: metadataData.tags || [],
+			isVisible: metadataData.isVisible !== undefined ? metadataData.isVisible : false,
+			isVerified: metadataData.isVerified !== undefined ? metadataData.isVerified : false,
+			metadatasUpdatedAt: Array(13).fill(new Date().getTime()) // 13 updateable fields
+		}
+
+		await prisma.avsCuratedMetadata.create({
+			data: createData
+		})
+
+		res.send({ success: true })
+	} catch (error) {
+		handleAndReturnErrorResponse(req, res, error)
+	}
+}
+
+/**
  * Function for route /avs/:address/update-metadata
  * Protected route to update the curated metadata of a given AVS
  *
@@ -813,8 +891,10 @@ export async function updateMetadata(req: Request, res: Response) {
 		const updatedAtTimestamps = [...(currentRecord.metadatasUpdatedAt || [])]
 
 		// Ensure exact array length
+		// 0n in the final array means the field has never been updated
+		// and the record was created before introduction of `createMetadata` in the API spec
 		while (updatedAtTimestamps.length < metadataFields.length) {
-			updatedAtTimestamps.push(0n) // 0n in the final array would imply that the field has never been edited
+			updatedAtTimestamps.push(0n)
 		}
 
 		let hasChanges = false
@@ -877,6 +957,49 @@ export async function updateMetadata(req: Request, res: Response) {
 		})
 
 		res.send({ updated: updateCount })
+	} catch (error) {
+		handleAndReturnErrorResponse(req, res, error)
+	}
+}
+
+/**
+ * Function for route /avs/:address/delete-metadata
+ * Protected route to delete the curated metadata of a given AVS
+ *
+ * @param req
+ * @param res
+ */
+export async function deleteMetadata(req: Request, res: Response) {
+	const paramCheck = EthereumAddressSchema.safeParse(req.params.address)
+	if (!paramCheck.success) {
+		return handleAndReturnErrorResponse(req, res, paramCheck.error)
+	}
+
+	try {
+		const accessLevel = isAuthRequired() ? req.accessLevel || 0 : 999
+
+		if (accessLevel !== 999) {
+			throw new EigenExplorerApiError({ code: 'unauthorized', message: 'Unauthorized access.' })
+		}
+
+		const { address } = req.params
+
+		const existingRecord = await prisma.avsCuratedMetadata.findUnique({
+			where: { avsAddress: address.toLowerCase() }
+		})
+
+		if (!existingRecord) {
+			throw new EigenExplorerApiError({
+				code: 'not_found',
+				message: 'Metadata for this AVS not found.'
+			})
+		}
+
+		await prisma.avsCuratedMetadata.delete({
+			where: { avsAddress: address.toLowerCase() }
+		})
+
+		res.send({ success: true })
 	} catch (error) {
 		handleAndReturnErrorResponse(req, res, error)
 	}

--- a/packages/api/src/routes/avs/avsRoutes.ts
+++ b/packages/api/src/routes/avs/avsRoutes.ts
@@ -9,7 +9,9 @@ import {
 	getAVSRewardsEvents,
 	invalidateMetadata,
 	getAvsRegistrationEvents,
-	updateMetadata
+	createMetadata,
+	updateMetadata,
+	deleteMetadata
 } from './avsController'
 
 import routeCache from 'route-cache'
@@ -40,6 +42,10 @@ router.get(
 // Protected routes
 router.get('/:address/invalidate-metadata', routeCache.cacheSeconds(120), invalidateMetadata)
 
+router.post('/:address/create-metadata', createMetadata)
+
 router.post('/:address/update-metadata', updateMetadata)
+
+router.post('/:address/delete-metadata', deleteMetadata)
 
 export default router

--- a/packages/api/src/schema/zod/schemas/updateMetadata.ts
+++ b/packages/api/src/schema/zod/schemas/updateMetadata.ts
@@ -2,17 +2,17 @@ import z from '../'
 import { EthereumAddressSchema } from './base/ethereumAddress'
 
 export const UpdateMetadataSchema = z.object({
-	metadataName: z.string().nullable(),
-	metadataDescription: z.string().nullable(),
-	metadataDiscord: z.string().nullable(),
-	metadataLogo: z.string().nullable(),
-	metadataTelegram: z.string().nullable(),
-	metadataWebsite: z.string().nullable(),
-	metadataX: z.string().nullable(),
-	metadataGithub: z.string().nullable(),
-	metadataTokenAddress: EthereumAddressSchema.nullable(),
-	additionalConfig: z.record(z.string(), z.string()).nullable(),
-	tags: z.array(z.string()).nullable(),
-	isVisible: z.boolean().nullable(),
-	isVerified: z.boolean().nullable()
+	metadataName: z.string().nullable().optional(),
+	metadataDescription: z.string().nullable().optional(),
+	metadataDiscord: z.string().nullable().optional(),
+	metadataLogo: z.string().nullable().optional(),
+	metadataTelegram: z.string().nullable().optional(),
+	metadataWebsite: z.string().nullable().optional(),
+	metadataX: z.string().nullable().optional(),
+	metadataGithub: z.string().nullable().optional(),
+	metadataTokenAddress: EthereumAddressSchema.nullable().optional(),
+	additionalConfig: z.record(z.string(), z.string()).nullable().optional(),
+	tags: z.array(z.string()).optional(),
+	isVisible: z.boolean().optional(),
+	isVerified: z.boolean().optional()
 })

--- a/packages/prisma/migrations/20250410100654_include_metadata_additional_config/migration.sql
+++ b/packages/prisma/migrations/20250410100654_include_metadata_additional_config/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE "AvsCuratedMetadata" ADD COLUMN     "additionalConfig" JSONB;

--- a/packages/prisma/migrations/20250410100654_update_curated_metadata_usage/migration.sql
+++ b/packages/prisma/migrations/20250410100654_update_curated_metadata_usage/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "AvsCuratedMetadata" ADD COLUMN     "additionalConfig" JSONB;
+
+-- AlterTable
+ALTER TABLE "AvsCuratedMetadata" ADD COLUMN     "metadatasUpdatedAt" BIGINT[];

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -61,6 +61,8 @@ model AvsCuratedMetadata {
   isVisible  Boolean  @default(false)
   isVerified Boolean  @default(false)
 
+  metadatasUpdatedAt BigInt[]
+
   @@index([tags], map: "tags_1")
 }
 


### PR DESCRIPTION
## Metadata Updation Timestamps

We now capture the update timestamp for each metadata field, when it is updated via API.

The caller can attach fields requiring update in the request body. The API function checks if there's an update required and then writes to db. All the fields that were updated will have the current timestamp captured and written to the new `metadatasUpdatedAt` ordered array of timestamps.

Note: API supports updating nullable fields to `null`
```
POST /avs/:address/update-metadata
body: {
    "metadataTelegram": "test",
    "isVerified": true,    <-- Same as db value, so will not update
    "tags": ["Oracle", "Test"],
    "additionalConfig": { "foo": "bar" }
}

Response:
{ "updated": 3 }
```

The `withCuratedMetadata` flag now returns`metadatasUpdatedAt`.
Note: A value of 0 means the field has never been updated and the record was created before the introduction of adding metadata via API
```
GET /avs/:address?withCuratedMetadata=true

"metadatasUpdatedAt": [
    0,
    0,
    0,
    0,
    1744716585186,
    0,
    0,
    0,
    0,
    0,
    1744716585186,
    0,
    1744716541217
]
```

The order of the timestamps corresponds to the order of fields in `schema.prisma`

```
[
    'metadataName',
    'metadataDescription',
    'metadataDiscord',
    'metadataLogo',
    'metadataTelegram',
    'metadataWebsite',
    'metadataX',
    'metadataGithub',
    'metadataTokenAddress',
    'additionalConfig',
    'tags',
    'isVisible',
    'isVerified'
]
```

## Adding Curated Metadata via API

The caller can add the fields they want during creation, to the POST body. Fields not added will be given default values.
Note: The `metadatasUpdatedAt` array is populated with the current timestamp for all fields.
```
POST /avs/:address/create-metadata
body: {
    "metadataName": "Aethos",
    "isVerified": true
}

Response:
{ "success": true }
```

## Deleting Curated Metadata via API
```
POST /avs/:address/delete-metadata

{ "success": true }
```