### PR TITLE
Trailing Apy

### DIFF
--- a/packages/api/src/routes/metrics/metricController.ts
+++ b/packages/api/src/routes/metrics/metricController.ts
@@ -2268,7 +2268,7 @@ function resetTime(date: Date) {
  *
  * @returns
  */
-async function fetchCurrentEthPrices(): Promise<Map<string, number>> {
+export async function fetchCurrentEthPrices(): Promise<Map<string, number>> {
 	const prismaClient = getPrismaClient()
 	const strategies = await prismaClient.strategies.findMany()
 	const tokenPrices = await fetchTokenPrices()

--- a/packages/api/src/routes/operators/operatorController.ts
+++ b/packages/api/src/routes/operators/operatorController.ts
@@ -22,6 +22,11 @@ import prisma from '../../utils/prismaClient'
 import { fetchTokenPrices } from '../../utils/tokenPrices'
 import { fetchDelegationEvents, fetchRegistrationEvents } from '../../utils/eventUtils'
 import { MinTvlQuerySchema } from '../../schema/zod/schemas/minTvlQuerySchema'
+import { WithTrailingApySchema } from '../../schema/zod/schemas/withTrailingApySchema'
+import {
+	buildOperatorAvsRegistrationMap,
+	getDailyAvsStrategyTvl
+} from '../../utils/trailingApyUtils'
 
 /**
  * Function for route /operators
@@ -135,6 +140,7 @@ export async function getAllOperators(req: Request, res: Response) {
 export async function getOperator(req: Request, res: Response) {
 	const result = WithTvlQuerySchema.and(WithAdditionalDataQuerySchema)
 		.and(WithRewardsQuerySchema)
+		.and(WithTrailingApySchema)
 		.safeParse(req.query)
 	if (!result.success) {
 		return handleAndReturnErrorResponse(req, res, result.error)
@@ -145,7 +151,7 @@ export async function getOperator(req: Request, res: Response) {
 		return handleAndReturnErrorResponse(req, res, paramCheck.error)
 	}
 
-	const { withTvl, withAvsData, withRewards } = result.data
+	const { withTvl, withAvsData, withRewards, withTrailingApy } = result.data
 
 	try {
 		const { address } = req.params
@@ -157,7 +163,7 @@ export async function getOperator(req: Request, res: Response) {
 					select: {
 						avsAddress: true,
 						isActive: true,
-						...(withAvsData || withRewards
+						...(withAvsData || withRewards || withTrailingApy
 							? {
 									avs: {
 										select: {
@@ -182,7 +188,7 @@ export async function getOperator(req: Request, res: Response) {
 														updatedAt: true
 												  }
 												: {}),
-											...(withRewards
+											...(withRewards || withTrailingApy
 												? {
 														address: true,
 														maxApy: true,
@@ -224,7 +230,10 @@ export async function getOperator(req: Request, res: Response) {
 			totalStakers: operator.totalStakers,
 			totalAvs: operator.totalAvs,
 			tvl: withTvl ? sharesToTVL(operator.shares, strategiesWithSharesUnderlying) : undefined,
-			rewards: withRewards ? await calculateOperatorApy(operator) : undefined,
+			rewards:
+				withRewards || withTrailingApy
+					? await calculateOperatorApy(operator, withTrailingApy)
+					: undefined,
 			stakers: undefined,
 			metadataUrl: undefined,
 			isMetadataSynced: undefined,
@@ -544,7 +553,7 @@ export function getOperatorSearchQuery(
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-async function calculateOperatorApy(operator: any) {
+async function calculateOperatorApy(operator: any, withTrailingApy: boolean = false) {
 	try {
 		const avsApyMap: Map<
 			string,
@@ -554,6 +563,11 @@ async function calculateOperatorApy(operator: any) {
 				strategyApys: {
 					strategyAddress: string
 					apy: number
+					trailingApy7d?: number
+					trailingApy30d?: number
+					trailingApy3m?: number
+					trailingApy6m?: number
+					trailingApy1y?: number
 					tokens: {
 						tokenAddress: string
 						apy: number
@@ -561,55 +575,123 @@ async function calculateOperatorApy(operator: any) {
 				}[]
 			}
 		> = new Map()
+		const strategyTvlMap: Map<string, number> = new Map()
+		const operatorStrategyTvlMap: Map<string, bigint> = new Map()
 
-		const tokenPrices = await fetchTokenPrices()
-		const strategiesWithSharesUnderlying = await getStrategiesWithShareUnderlying()
+		const startDate = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000)
+		startDate.setUTCHours(0, 0, 0, 0)
+		const endDate = new Date()
+		endDate.setUTCHours(0, 0, 0, 0)
 
-		// Grab the all reward submissions that the Operator is eligible for basis opted strategies & AVSs
-		const optedStrategyAddresses: Set<string> = new Set(
-			operator?.shares.map((share) => share.strategyAddress.toLowerCase())
+		if (!operator?.shares?.length) {
+			return []
+		}
+
+		operator.shares.forEach((share) =>
+			operatorStrategyTvlMap.set(share.strategyAddress.toLowerCase(), BigInt(share.shares))
 		)
-		const avsWithEligibleRewardSubmissions = operator?.avs
-			.filter((avsOp) => avsOp.avs.rewardSubmissions.length > 0)
+
+		// Filter AVS with reward submissions
+		const avsWithRewards = operator.avs.filter((avsOp) => avsOp.avs.rewardSubmissions.length > 0)
+
+		const pastYearStartSec = Math.floor(startDate.getTime() / 1000)
+		// Filter AVS with eligible rewards
+		const isEligibleReward = (reward: any) => {
+			const endTimeSec = reward.startTimestamp + BigInt(reward.duration)
+			return (
+				(operatorStrategyTvlMap.get(reward.strategyAddress.toLowerCase()) ?? 0n) > 0n &&
+				endTimeSec >= BigInt(pastYearStartSec)
+			)
+		}
+		const avsWithEligibleRewardSubmissions = avsWithRewards
 			.map((avsOp) => ({
 				avs: avsOp.avs,
-				eligibleRewards: avsOp.avs.rewardSubmissions.filter((reward) =>
-					optedStrategyAddresses.has(reward.strategyAddress.toLowerCase())
-				)
+				eligibleRewards: avsOp.avs.rewardSubmissions.filter(isEligibleReward),
+				status: avsOp.isActive
 			}))
 			.filter((item) => item.eligibleRewards.length > 0)
 
 		if (!avsWithEligibleRewardSubmissions || avsWithEligibleRewardSubmissions.length === 0)
 			return []
 
-		for (const avs of avsWithEligibleRewardSubmissions) {
+		const avsStrategyPairs = withTrailingApy
+			? avsWithEligibleRewardSubmissions.flatMap(({ avs, eligibleRewards }) =>
+					[...new Set(eligibleRewards.map((r: any) => r.strategyAddress.toLowerCase()))].map(
+						(strategyAddress) => ({
+							avsAddress: avs.address,
+							strategyAddress
+						})
+					)
+			  )
+			: []
+
+		const avsOperators = avsWithRewards.map((avsOp) => ({
+			avsAddress: avsOp.avsAddress,
+			isActive: avsOp.isActive
+		}))
+
+		// Parallelize initial data fetching
+		const [tokenPrices, strategiesWithSharesUnderlying, avsRegistrationByDay, dailyTvlMap] =
+			await Promise.all([
+				fetchTokenPrices(),
+				getStrategiesWithShareUnderlying(),
+				withTrailingApy
+					? buildOperatorAvsRegistrationMap(
+							operator.address.toLowerCase(),
+							avsOperators,
+							startDate,
+							endDate
+					  )
+					: [],
+				withTrailingApy ? getDailyAvsStrategyTvl(avsStrategyPairs, startDate, endDate) : {}
+			])
+		const tokenPriceMap = new Map(tokenPrices.map((tp) => [tp.address.toLowerCase(), tp]))
+
+		// Process Projected and Trailing APY for AVSs
+		for (const { avs, eligibleRewards, status } of avsWithEligibleRewardSubmissions) {
+			const avsAddressLower = avs.address.toLowerCase()
 			const strategyApyMap: Map<
 				string,
 				{
 					apy: number
+					trailingApy7d?: number
+					trailingApy30d?: number
+					trailingApy3m?: number
+					trailingApy6m?: number
+					trailingApy1y?: number
 					tokens: Map<string, number>
 				}
 			> = new Map()
 
-			const shares = withOperatorShares(avs.avs.operators).filter(
-				(s) => avs.avs.restakeableStrategies?.indexOf(s.strategyAddress.toLowerCase()) !== -1
+			const shares = withOperatorShares(avs.operators).filter(
+				(s) => avs.restakeableStrategies?.indexOf(s.strategyAddress.toLowerCase()) !== -1
 			)
 
 			// Fetch the AVS tvl for each strategy
 			const tvlStrategiesEth = sharesToTVLStrategies(shares, strategiesWithSharesUnderlying)
 
-			// Iterate through each strategy and calculate all its rewards
-			for (const strategyAddress of avs.avs.restakeableStrategies) {
-				// Omit strategy where the Operator doesn't have shares
-				if (
-					!operator.shares.find(
-						(share) => share.strategyAddress.toLowerCase() === strategyAddress.toLowerCase()
-					)
-				)
-					continue
+			// Process strategies for Current and Trailing APY
+			for (const strategyAddress of avs.restakeableStrategies || []) {
+				const strategyAddressLower = strategyAddress.toLowerCase()
 
-				const strategyTvl = tvlStrategiesEth[strategyAddress.toLowerCase()] || 0
+				if (
+					!operatorStrategyTvlMap.has(strategyAddressLower) ||
+					operatorStrategyTvlMap.get(strategyAddressLower) === 0n
+				) {
+					continue
+				}
+
+				const strategyTvl = tvlStrategiesEth[strategyAddressLower] || 0
 				if (strategyTvl === 0) continue
+
+				// Filter eligibleRewards by strategy; validate duration and timestamp
+				const relevantSubmissions = eligibleRewards.filter(
+					(submission) => submission.strategyAddress.toLowerCase() === strategyAddressLower
+				)
+
+				if (!relevantSubmissions || relevantSubmissions.length === 0) continue
+
+				strategyTvlMap.set(strategyAddressLower, strategyTvl)
 
 				const tokenApyMap: Map<string, number> = new Map()
 				const tokenRewards: Map<
@@ -619,87 +701,152 @@ async function calculateOperatorApy(operator: any) {
 						totalDuration: number
 					}
 				> = new Map()
+				const dailyRewardsByDay: { [day: string]: Prisma.Prisma.Decimal } = {}
 
-				let strategyTotalRewardsEth = new Prisma.Prisma.Decimal(0)
-				let strategyTotalDuration = 0
-
-				// Find all reward submissions for the strategy
-				const relevantSubmissions = avs.avs.rewardSubmissions.filter(
-					(submission) => submission.strategyAddress.toLowerCase() === strategyAddress.toLowerCase()
-				)
-
-				// Calculate each reward amount for the strategy
+				// Process submissions for both Current and Trailing APY
 				for (const submission of relevantSubmissions) {
 					let rewardIncrementEth = new Prisma.Prisma.Decimal(0)
 					const rewardTokenAddress = submission.token.toLowerCase()
 
 					// Normalize reward amount to its ETH price
 					if (rewardTokenAddress) {
-						const tokenPrice = tokenPrices.find(
-							(tp) => tp.address.toLowerCase() === rewardTokenAddress
-						)
+						const tokenPrice = tokenPriceMap.get(rewardTokenAddress)
+
+						// Apply operator commission (90% of rewards)
 						rewardIncrementEth = submission.amount
 							.mul(new Prisma.Prisma.Decimal(tokenPrice?.ethPrice ?? 0))
 							.div(new Prisma.Prisma.Decimal(10).pow(tokenPrice?.decimals ?? 18))
+							.mul(90)
+							.div(100)
 					}
 
-					// Apply operator commission (90% of rewards)
-					rewardIncrementEth = rewardIncrementEth
-						.mul(submission.multiplier)
-						.div(new Prisma.Prisma.Decimal(10).pow(18))
-						.mul(90)
-						.div(100)
-
+					// Current APY: Accumulate only for active AVSs
 					// Accumulate token-specific rewards and duration
 					const tokenData = tokenRewards.get(rewardTokenAddress) || {
 						totalRewardsEth: new Prisma.Prisma.Decimal(0),
 						totalDuration: 0
 					}
-					tokenData.totalRewardsEth = tokenData.totalRewardsEth.add(rewardIncrementEth)
+					tokenData.totalRewardsEth = status
+						? tokenData.totalRewardsEth.add(rewardIncrementEth)
+						: (tokenData.totalRewardsEth = new Prisma.Prisma.Decimal(0))
 					tokenData.totalDuration += submission.duration
 					tokenRewards.set(rewardTokenAddress, tokenData)
 
-					// Accumulate strategy totals
-					strategyTotalRewardsEth = strategyTotalRewardsEth.add(rewardIncrementEth)
-					strategyTotalDuration += submission.duration
+					// Trailing APY: Distribute daily rewards if requested
+					if (withTrailingApy) {
+						const startTime = new Date(Number(submission.startTimestamp) * 1000)
+						const durationDays = submission.duration / 86400
+						if (durationDays <= 0) continue
+
+						const dailyRewardEth = rewardIncrementEth.div(new Prisma.Prisma.Decimal(durationDays))
+
+						const endTime = new Date(startTime)
+						endTime.setDate(endTime.getDate() + Math.floor(durationDays) - 1)
+						for (
+							let day = new Date(Math.max(startTime.getTime(), startDate.getTime()));
+							day <= endTime && day <= endDate;
+							day.setDate(day.getDate() + 1)
+						) {
+							const dayKey = day.toISOString().split('T')[0]
+							if (!dailyRewardsByDay[dayKey]) {
+								dailyRewardsByDay[dayKey] = new Prisma.Prisma.Decimal(0)
+							}
+							dailyRewardsByDay[dayKey] = dailyRewardsByDay[dayKey].add(dailyRewardEth)
+						}
+					}
 				}
 
-				if (strategyTotalDuration === 0) continue
-
-				// Calculate token APYs
+				// Calculate token APYs for Current APY, only for active AVSs
+				let strategyApy = 0
 				tokenRewards.forEach((data, tokenAddress) => {
 					if (data.totalDuration !== 0) {
 						const tokenRewardRate = data.totalRewardsEth.toNumber() / strategyTvl
 						const tokenAnnualizedRate =
 							tokenRewardRate * ((365 * 24 * 60 * 60) / data.totalDuration)
 						const tokenApy = tokenAnnualizedRate * 100
-
 						tokenApyMap.set(tokenAddress, tokenApy)
+						strategyApy += tokenApy
 					}
 				})
 
-				// Calculate overall strategy APY
-				const strategyApy = Array.from(tokenApyMap.values()).reduce((sum, apy) => sum + apy, 0)
-				if (strategyApy > 0) {
-					strategyApyMap.set(strategyAddress, {
-						apy: strategyApy,
-						tokens: tokenApyMap
+				// Initialize strategy data
+				const strategyData = {
+					apy: strategyApy,
+					tokens: tokenApyMap
+				}
+
+				// Calculate Trailing APY if requested, for both active and non-active AVSs
+				if (withTrailingApy) {
+					// Define timeframe boundaries
+					const timeframes = [
+						{ days: 7, key: 'trailingApy7d' },
+						{ days: 30, key: 'trailingApy30d' },
+						{ days: 90, key: 'trailingApy3m' },
+						{ days: 180, key: 'trailingApy6m' },
+						{ days: 365, key: 'trailingApy1y' }
+					]
+					const timeframeStarts: { [key: string]: Date } = {}
+					const trailingSums: { [key: string]: number } = {}
+					timeframes.forEach(({ key, days }) => {
+						const start = new Date(Date.now() - (days - 1) * 24 * 60 * 60 * 1000)
+						start.setUTCHours(0, 0, 0, 0)
+						timeframeStarts[key] = start
+						trailingSums[key] = 0
+					})
+
+					// Calculate daily APY and accumulate for relevant timeframes
+					for (let day = new Date(startDate); day <= endDate; day.setDate(day.getDate() + 1)) {
+						const dayKey = day.toISOString().split('T')[0]
+						const isRegistered = avsRegistrationByDay[dayKey]?.[avsAddressLower] || false
+						if (!isRegistered) continue
+
+						const dailyTvl = dailyTvlMap[dayKey]?.[avsAddressLower]?.[strategyAddressLower] || 0
+						if (dailyTvl === 0) continue
+
+						const dailyStrategyRewardsEth =
+							dailyRewardsByDay[dayKey] || new Prisma.Prisma.Decimal(0)
+
+						if (dailyStrategyRewardsEth.greaterThan(0)) {
+							const dailyApy = dailyStrategyRewardsEth.div(dailyTvl).mul(100).toNumber()
+							timeframes.forEach(({ key }) => {
+								if (day >= timeframeStarts[key]) {
+									trailingSums[key] += dailyApy
+								}
+							})
+						}
+					}
+
+					// Annualize trailing APYs
+					timeframes.forEach(({ key, days }) => {
+						const annualizationFactor = new Prisma.Prisma.Decimal(365).div(days)
+						strategyData[key] = new Prisma.Prisma.Decimal(trailingSums[key])
+							.mul(annualizationFactor)
+							.toNumber()
 					})
 				}
+
+				strategyApyMap.set(strategyAddressLower, strategyData)
 			}
 
-			avsApyMap.set(avs.avs.address, {
-				avsAddress: avs.avs.address,
-				maxApy: Math.max(...Array.from(strategyApyMap.values()).map((data) => data.apy)),
-				strategyApys: Array.from(strategyApyMap.entries()).map(([strategyAddress, data]) => ({
-					strategyAddress,
-					apy: data.apy,
-					tokens: Array.from(data.tokens.entries()).map(([tokenAddress, apy]) => ({
-						tokenAddress,
-						apy
+			if (strategyApyMap.size > 0) {
+				avsApyMap.set(avs.address, {
+					avsAddress: avs.address,
+					maxApy: Math.max(...Array.from(strategyApyMap.values()).map((data) => data.apy)),
+					strategyApys: Array.from(strategyApyMap.entries()).map(([strategyAddress, data]) => ({
+						strategyAddress,
+						apy: data.apy,
+						trailingApy7d: data.trailingApy7d,
+						trailingApy30d: data.trailingApy30d,
+						trailingApy3m: data.trailingApy3m,
+						trailingApy6m: data.trailingApy6m,
+						trailingApy1y: data.trailingApy1y,
+						tokens: Array.from(data.tokens.entries()).map(([tokenAddress, apy]) => ({
+							tokenAddress,
+							apy
+						}))
 					}))
-				}))
-			})
+				})
+			}
 		}
 
 		return Array.from(avsApyMap.values())

--- a/packages/api/src/schema/zod/schemas/withTrailingApySchema.ts
+++ b/packages/api/src/schema/zod/schemas/withTrailingApySchema.ts
@@ -1,0 +1,10 @@
+import z from '..'
+
+export const WithTrailingApySchema = z.object({
+	withTrailingApy: z
+		.enum(['true', 'false'])
+		.default('false')
+		.describe('Toggle whether the route should calculate the Trailing APY Values')
+		.transform((val) => val === 'true')
+		.openapi({ example: 'false' })
+})

--- a/packages/api/src/schema/zod/schemas/withTvlQuery.ts
+++ b/packages/api/src/schema/zod/schemas/withTvlQuery.ts
@@ -8,3 +8,12 @@ export const WithTvlQuerySchema = z.object({
 		.transform((val) => val === 'true')
 		.openapi({ example: 'false' })
 })
+
+export const WithTrailingApySchema = z.object({
+	withTrailingAPY: z
+		.enum(['true', 'false'])
+		.default('false')
+		.describe('')
+		.transform((val) => val === 'true')
+		.openapi({ example: 'false' })
+})

--- a/packages/api/src/schema/zod/schemas/withTvlQuery.ts
+++ b/packages/api/src/schema/zod/schemas/withTvlQuery.ts
@@ -8,12 +8,3 @@ export const WithTvlQuerySchema = z.object({
 		.transform((val) => val === 'true')
 		.openapi({ example: 'false' })
 })
-
-export const WithTrailingApySchema = z.object({
-	withTrailingAPY: z
-		.enum(['true', 'false'])
-		.default('false')
-		.describe('')
-		.transform((val) => val === 'true')
-		.openapi({ example: 'false' })
-})

--- a/packages/api/src/utils/baseApys.ts
+++ b/packages/api/src/utils/baseApys.ts
@@ -1,0 +1,110 @@
+import { cacheStore } from 'route-cache'
+import { getPrismaClient } from './prismaClient'
+
+type BaseApy = {
+	poolId: string
+	strategyAddress: string
+	tokenAddress: string
+	apy: number
+}
+
+export async function fetchBaseApys(): Promise<BaseApy[]> {
+	const prismaClient = getPrismaClient()
+
+	// Fetch strategy metadata
+	const strategies = await prismaClient.strategies.findMany({
+		select: {
+			address: true,
+			underlyingToken: true
+		}
+	})
+
+	// Fetch token metadata for dlPoolId
+	const underlyingTokenAddresses = strategies.map((s) => s.underlyingToken.toLowerCase())
+	const tokens = await prismaClient.tokens.findMany({
+		where: {
+			address: {
+				in: underlyingTokenAddresses
+			}
+		},
+		select: {
+			address: true,
+			dlPoolId: true
+		}
+	})
+
+	// Map tokens by address for quick lookup
+	const tokenPoolIdMap = new Map(tokens.map((t) => [t.address.toLowerCase(), t.dlPoolId]))
+
+	const baseApys: BaseApy[] = []
+	const minHours = 12 // Minimum TTL in hours
+	const maxHours = 24 // Maximum TTL in hours
+
+	// Process each strategy
+	for (const strategy of strategies) {
+		const dlPoolId = tokenPoolIdMap.get(strategy.underlyingToken.toLowerCase())
+		if (!dlPoolId) {
+			// No pool ID, use default APY
+			baseApys.push({
+				poolId: tokenPoolIdMap.get(strategy.underlyingToken.toLowerCase()) || '',
+				strategyAddress: strategy.address,
+				tokenAddress: strategy.underlyingToken.toLowerCase(),
+				apy: 0
+			})
+			continue
+		}
+
+		const cacheKey = `apy_${strategy.address}`
+		const cachedApy = await cacheStore.get(cacheKey)
+
+		if (cachedApy !== undefined && cachedApy !== null) {
+			// Cache hit
+			baseApys.push({
+				poolId: tokenPoolIdMap.get(strategy.underlyingToken.toLowerCase()) || '',
+				strategyAddress: strategy.address,
+				tokenAddress: strategy.underlyingToken.toLowerCase(),
+				apy: cachedApy
+			})
+			continue
+		}
+
+		// Cache miss: fetch APY from DeFi Llama
+		try {
+			const response = await fetch(`https://yields.llama.fi/chart/${dlPoolId}`)
+
+			if (!response.ok) {
+				throw new Error(`DeFi Llama API error for pool ${dlPoolId}: ${response.statusText}`)
+			}
+
+			const data = await response.json()
+			if (data.status !== 'success' || !data.data || !data.data.length) {
+				throw new Error(`Invalid APY data for pool ${dlPoolId}: ${JSON.stringify(data)}`)
+			}
+
+			const latestEntry = data.data[data.data.length - 1]
+			const apyBase = Number(latestEntry.apyBase) || 0
+
+			// Cache APY with random TTL
+			const randomHour = Math.floor(Math.random() * (maxHours - minHours + 1)) + minHours // Random hour: 12 to 24
+			const ttlMillis = randomHour * 3_600_000 // Convert hours to milliseconds
+			await cacheStore.set(cacheKey, apyBase, ttlMillis)
+
+			baseApys.push({
+				poolId: dlPoolId,
+				strategyAddress: strategy.address,
+				tokenAddress: strategy.underlyingToken.toLowerCase(),
+				apy: apyBase
+			})
+		} catch (error) {
+			console.error(`Error fetching APY for pool ${dlPoolId}:`, error)
+			baseApys.push({
+				poolId: dlPoolId || '',
+				strategyAddress: strategy.address,
+				tokenAddress: strategy.underlyingToken.toLowerCase(),
+				apy: 0
+			})
+		}
+	}
+
+	return baseApys
+}

--- a/packages/api/src/utils/trailingApyUtils.ts
+++ b/packages/api/src/utils/trailingApyUtils.ts
@@ -47,7 +47,7 @@ export async function getDailyAvsStrategyTvl(
 			tvl: true,
 			timestamp: true
 		},
-		orderBy: [{ avsAddress: 'asc' }, { strategyAddress: 'asc' }, { timestamp: 'asc' }]
+		orderBy: [{ timestamp: 'asc' }]
 	})
 
 	// Group records by AVS-strategy pair and convert TVL to ETH

--- a/packages/api/src/utils/trailingApyUtils.ts
+++ b/packages/api/src/utils/trailingApyUtils.ts
@@ -1,0 +1,100 @@
+import prisma from './prismaClient'
+import Prisma from '@prisma/client'
+import { fetchCurrentEthPrices } from '../routes/metrics/metricController'
+
+interface DailyAvsStrategyTvlMap {
+	[dayKey: string]: { [avsAddress: string]: { [strategyAddress: string]: number } }
+}
+
+export async function getDailyAvsStrategyTvl(
+	avsStrategyPairs: { avsAddress: string; strategyAddress: string }[],
+	startDate: Date,
+	endDate: Date
+): Promise<DailyAvsStrategyTvlMap> {
+	startDate = new Date(startDate.setUTCHours(0, 0, 0, 0))
+	endDate = new Date(endDate.setUTCHours(0, 0, 0, 0))
+
+	const dailyTvlMap: DailyAvsStrategyTvlMap = {}
+
+	const dayKeys: string[] = []
+	for (let day = new Date(startDate); day <= endDate; day.setDate(day.getDate() + 1)) {
+		const dayKey = day.toISOString().split('T')[0]
+		dayKeys.push(dayKey)
+		dailyTvlMap[dayKey] = {}
+	}
+
+	if (avsStrategyPairs.length === 0) {
+		return dailyTvlMap
+	}
+
+	const strategyPriceMap = await fetchCurrentEthPrices()
+
+	// Fetch TVL records
+	const tvlRecords = await prisma.metricAvsStrategyUnit.findMany({
+		where: {
+			OR: avsStrategyPairs.map(({ avsAddress, strategyAddress }) => ({
+				avsAddress: avsAddress.toLowerCase(),
+				strategyAddress: strategyAddress.toLowerCase()
+			})),
+			timestamp: {
+				gte: startDate,
+				lte: endDate
+			}
+		},
+		select: {
+			avsAddress: true,
+			strategyAddress: true,
+			tvl: true,
+			timestamp: true
+		},
+		orderBy: [{ avsAddress: 'asc' }, { strategyAddress: 'asc' }, { timestamp: 'asc' }]
+	})
+
+	// Group records by AVS-strategy pair and convert TVL to ETH
+	const recordsByPair = new Map<string, Array<{ timestamp: Date; tvl: number }>>()
+	for (const record of tvlRecords) {
+		const key = `${record.avsAddress}:${record.strategyAddress}`
+		if (!recordsByPair.has(key)) {
+			recordsByPair.set(key, [])
+		}
+		const ethPrice = strategyPriceMap.get(record.strategyAddress.toLowerCase())
+		let tvlEth = 0
+		if (ethPrice && ethPrice > 0) {
+			// Convert TVL from native token to ETH
+			tvlEth = record.tvl.mul(new Prisma.Prisma.Decimal(ethPrice)).toNumber()
+		}
+		recordsByPair.get(key)!.push({
+			timestamp: record.timestamp,
+			tvl: tvlEth
+		})
+	}
+
+	// Fill daily TVL map
+	for (const { avsAddress, strategyAddress } of avsStrategyPairs) {
+		const avsAddr = avsAddress.toLowerCase()
+		const stratAddr = strategyAddress.toLowerCase()
+		const key = `${avsAddr}:${stratAddr}`
+		const records = recordsByPair.get(key) || []
+
+		let currentTvl = 0
+		let recordIndex = 0
+
+		for (const dayKey of dayKeys) {
+			const dayDate = new Date(dayKey)
+			while (
+				recordIndex < records.length &&
+				new Date(records[recordIndex].timestamp).setUTCHours(0, 0, 0, 0) <= dayDate.getTime()
+			) {
+				currentTvl = records[recordIndex].tvl
+				recordIndex++
+			}
+
+			if (!dailyTvlMap[dayKey][avsAddr]) {
+				dailyTvlMap[dayKey][avsAddr] = {}
+			}
+			dailyTvlMap[dayKey][avsAddr][stratAddr] = currentTvl
+		}
+	}
+
+	return dailyTvlMap
+}

--- a/packages/prisma/migrations/20250520085049_include_defi_llama_id_info/migration.sql
+++ b/packages/prisma/migrations/20250520085049_include_defi_llama_id_info/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Tokens" ADD COLUMN     "dlPoolId" TEXT;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -114,7 +114,8 @@ model Tokens {
   name     String
   decimals Int
 
-  cmcId Int
+  cmcId    Int
+  dlPoolId String?
 
   createdAtBlock BigInt   @default(0)
   updatedAtBlock BigInt   @default(0)

--- a/packages/seeder/src/monitors/avsApy.ts
+++ b/packages/seeder/src/monitors/avsApy.ts
@@ -17,9 +17,12 @@ export async function monitorAvsApy() {
 
 	let skip = 0
 	const take = 32
+	const MAX_APY = 9999.9999
 
 	const tokenPrices = await fetchTokenPrices()
 	const strategiesWithSharesUnderlying = await getStrategiesWithShareUnderlying()
+
+	const startDate = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000)
 
 	while (true) {
 		try {
@@ -69,11 +72,14 @@ export async function monitorAvsApy() {
 						let totalRewardsEth = new Prisma.Prisma.Decimal(0)
 						let totalDuration = 0
 
-						// Find all reward submissions attributable to the strategy
-						const relevantSubmissions = avs.rewardSubmissions.filter(
-							(submission) =>
-								submission.strategyAddress.toLowerCase() === strategyAddress.toLowerCase()
-						)
+						const pastYearStartSec = Math.floor(startDate.getTime() / 1000)
+						const relevantSubmissions = avs.rewardSubmissions.filter((submission) => {
+							const endTimeSec = submission.startTimestamp + BigInt(submission.duration)
+							return (
+								submission.strategyAddress.toLowerCase() === strategyAddress.toLowerCase() &&
+								endTimeSec >= BigInt(pastYearStartSec)
+							)
+						})
 
 						// Calculate each reward amount for the strategy
 						for (const submission of relevantSubmissions) {
@@ -89,11 +95,6 @@ export async function monitorAvsApy() {
 									.mul(new Prisma.Prisma.Decimal(tokenPrice?.ethPrice ?? 0))
 									.div(new Prisma.Prisma.Decimal(10).pow(tokenPrice?.decimals ?? 18)) // No decimals
 							}
-
-							// Multiply reward amount in ETH by the strategy weight
-							rewardIncrementEth = rewardIncrementEth
-								.mul(submission.multiplier)
-								.div(new Prisma.Prisma.Decimal(10).pow(18))
 
 							totalRewardsEth = totalRewardsEth.add(rewardIncrementEth) // No decimals
 							totalDuration += submission.duration
@@ -111,7 +112,9 @@ export async function monitorAvsApy() {
 
 					// Calculate max achievable APY
 					if (strategyRewardsMap.size > 0) {
-						const maxApy = new Prisma.Prisma.Decimal(Math.max(...strategyRewardsMap.values()))
+						const maxApy = new Prisma.Prisma.Decimal(
+							Math.min(Math.max(...strategyRewardsMap.values()), MAX_APY)
+						)
 
 						if (avs.maxApy !== maxApy) {
 							data.push({


### PR DESCRIPTION
Have added Trailing Apy for AVS and Operators to the `/avs/[address]` and `/operators/[address]` routes respectively

- For Trailing APY:
Adds the trailingApy fields to each entry of strategyApys when the withTrailingApy flag is enabled

```
"trailingApy7d":
"trailingApy30d";
"trailingApy3m":
"trailingApy6m": 
"trailingApy1y":
```

- For Base APY:
Adds baseApy field to each entry of strategyApys
`"baseApy": `

So after both additions the response looks like
```
"strategyApys": [
                {
                    "strategyAddress": "",
                    "apy": ,
                    "baseApy": ,
                    "trailingApy7d": ,
                    "trailingApy30d": ,
                    "trailingApy3m": ,
                    "trailingApy6m": ,
                    "trailingApy1y": ,
                    "tokens": [
                        {
                            "tokenAddress": "",
                            "apy":
                        }
                    ]
                }
]
```