### PR TITLE
[Feat] - Improve protected routes for AVS Metadata

### DIFF
--- a/packages/api/src/routes/avs/avsController.ts
+++ b/packages/api/src/routes/avs/avsController.ts
@@ -130,9 +130,7 @@ export async function getAllAVS(req: Request, res: Response) {
 				return {
 					...avs,
 					curatedMetadata: withCuratedMetadata ? avs.curatedMetadata : undefined, // Legacy
-					additionalInfo: withCuratedMetadata
-						? getAdditionalInfo(avs.additionalInfo, avs.curatedMetadata)
-						: undefined,
+					additionalInfo: withCuratedMetadata ? getAdditionalInfo(avs) : undefined,
 					totalOperators: avs.totalOperators,
 					totalStakers: avs.totalStakers,
 					shares,
@@ -233,6 +231,60 @@ export async function getAllAVSAddresses(req: Request, res: Response) {
 }
 
 /**
+ * Function for route /avs/get-all-metadata
+ * Protected route to return all AVS metadata, customized for admin access via area-internal-dashboard
+ *
+ * @param req
+ * @param res
+ */
+export async function getAllMetadata(req: Request, res: Response) {
+	try {
+		const accessLevel = isAuthRequired() ? req.accessLevel || 0 : 999
+
+		if (accessLevel !== 999) {
+			throw new EigenExplorerApiError({ code: 'unauthorized', message: 'Unauthorized access.' })
+		}
+
+		const skip = 0
+		const take = 1000
+		const allAvs = await prisma.avs.findMany({
+			include: {
+				additionalInfo: true,
+				curatedMetadata: true
+			},
+			skip,
+			take
+		})
+
+		// Process each AVS
+		const processedAvs = allAvs.map((avs) => ({
+			address: avs.address,
+			createdAt: avs.createdAt,
+			updatedAt: avs.updatedAt,
+			additionalInfo: getAdditionalInfo(avs)
+		}))
+
+		// Sort so bookmarked AVSs (metadataKey: 'bookmarked', metadataValue: 'true') come first
+		const sortedAvs = processedAvs.sort((a, b) => {
+			const aIsBookmarked = a.additionalInfo.some(
+				(info) => info.metadataKey === 'bookmarked' && info.metadataValue === 'true'
+			)
+			const bIsBookmarked = b.additionalInfo.some(
+				(info) => info.metadataKey === 'bookmarked' && info.metadataValue === 'true'
+			)
+
+			if (aIsBookmarked && !bIsBookmarked) return -1
+			if (!aIsBookmarked && bIsBookmarked) return 1
+			return 0
+		})
+
+		res.send({ data: sortedAvs, meta: { total: sortedAvs.length, skip, take } })
+	} catch (error) {
+		handleAndReturnErrorResponse(req, res, error)
+	}
+}
+
+/**
  * Function for route /avs/:address
  * Returns a single AVS by address
  *
@@ -302,9 +354,7 @@ export async function getAVS(req: Request, res: Response) {
 		res.send({
 			...avs,
 			curatedMetadata: withCuratedMetadata ? avs.curatedMetadata : undefined,
-			additionalInfo: withCuratedMetadata
-				? getAdditionalInfo(avs.additionalInfo, avs.curatedMetadata)
-				: undefined,
+			additionalInfo: withCuratedMetadata ? getAdditionalInfo(avs) : undefined,
 			shares,
 			totalOperators: avs.totalOperators,
 			totalStakers: newTotalStakers,
@@ -747,13 +797,14 @@ export async function getAvsRegistrationEvents(req: Request, res: Response) {
 }
 
 /**
- * Function for route /avs/:address/invalidate-metadata
- * Protected route to invalidate the metadata of a given AVS
+ * Function for route /avs/:address/get-metadata
+ * Protected route to return a given AVS metadata, customized for admin access via area-internal-dashboard
  *
  * @param req
  * @param res
  */
-export async function invalidateMetadata(req: Request, res: Response) {
+export async function getMetadata(req: Request, res: Response) {
+	// Validate query and params
 	const paramCheck = EthereumAddressSchema.safeParse(req.params.address)
 	if (!paramCheck.success) {
 		return handleAndReturnErrorResponse(req, res, paramCheck.error)
@@ -768,16 +819,19 @@ export async function invalidateMetadata(req: Request, res: Response) {
 
 		const { address } = req.params
 
-		const updateResult = await prisma.avs.updateMany({
+		const avs = await prisma.avs.findUniqueOrThrow({
 			where: { address: address.toLowerCase() },
-			data: { isMetadataSynced: false }
+			include: {
+				additionalInfo: true,
+				curatedMetadata: true
+			}
 		})
 
-		if (updateResult.count === 0) {
-			throw new EigenExplorerApiError({ code: 'not_found', message: 'AVS address not found.' })
-		}
-
-		res.send({ message: 'Metadata invalidated successfully.' })
+		res.send({
+			...avs,
+			additionalInfo: getAdditionalInfo(avs),
+			curatedMetadata: undefined
+		})
 	} catch (error) {
 		handleAndReturnErrorResponse(req, res, error)
 	}
@@ -946,13 +1000,13 @@ export async function deleteMetadata(req: Request, res: Response) {
 
 	try {
 		const accessLevel = isAuthRequired() ? req.accessLevel || 0 : 999
-		const deleteData = bodyCheck.data
 
 		if (accessLevel !== 999) {
 			throw new EigenExplorerApiError({ code: 'unauthorized', message: 'Unauthorized access.' })
 		}
 
 		const { address } = req.params
+		const deleteData = bodyCheck.data
 
 		const result = await prisma.avsAdditionalInfo.deleteMany({
 			where: {
@@ -1000,6 +1054,43 @@ export async function deleteAllMetadata(req: Request, res: Response) {
 		})
 
 		res.send({ deleted: result.count })
+	} catch (error) {
+		handleAndReturnErrorResponse(req, res, error)
+	}
+}
+
+/**
+ * Function for route /avs/:address/invalidate-metadata
+ * Protected route to invalidate the metadata of a given AVS
+ *
+ * @param req
+ * @param res
+ */
+export async function invalidateMetadata(req: Request, res: Response) {
+	const paramCheck = EthereumAddressSchema.safeParse(req.params.address)
+	if (!paramCheck.success) {
+		return handleAndReturnErrorResponse(req, res, paramCheck.error)
+	}
+
+	try {
+		const accessLevel = isAuthRequired() ? req.accessLevel || 0 : 999
+
+		if (accessLevel !== 999) {
+			throw new EigenExplorerApiError({ code: 'unauthorized', message: 'Unauthorized access.' })
+		}
+
+		const { address } = req.params
+
+		const updateResult = await prisma.avs.updateMany({
+			where: { address: address.toLowerCase() },
+			data: { isMetadataSynced: false }
+		})
+
+		if (updateResult.count === 0) {
+			throw new EigenExplorerApiError({ code: 'not_found', message: 'AVS address not found.' })
+		}
+
+		res.send({ message: 'Metadata invalidated successfully.' })
 	} catch (error) {
 		handleAndReturnErrorResponse(req, res, error)
 	}
@@ -1205,10 +1296,10 @@ async function calculateAvsApy(avs: any) {
 	} catch {}
 }
 
-function getAdditionalInfo(
-	allAdditionalInfo: Prisma.AvsAdditionalInfo[],
-	curatedMetadata: Prisma.AvsCuratedMetadata | null
-) {
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+function getAdditionalInfo(avs: any) {
+	const additionalInfo = avs.additionalInfo
+	const curatedMetadata = avs.curatedMetadata
 	const processedKeys = new Set<string>()
 	const result: Array<{
 		metadataKey: string
@@ -1217,7 +1308,7 @@ function getAdditionalInfo(
 		updatedAt: Date | null
 	}> = []
 
-	for (const info of allAdditionalInfo) {
+	for (const info of additionalInfo) {
 		result.push({
 			metadataKey: info.metadataKey,
 			metadataValue: info.metadataContent,
@@ -1228,38 +1319,45 @@ function getAdditionalInfo(
 		processedKeys.add(info.metadataKey)
 	}
 
-	// If curatedMetadata exists, use it as fallback if any of these keys are missing
-	if (curatedMetadata) {
-		const curatedFields = [
-			'metadataName',
-			'name',
-			'metadataDescription',
-			'description',
-			'metadataDiscord',
-			'discord',
-			'metadataLogo',
-			'logo',
-			'metadataTelegram',
-			'telegram',
-			'metadataWebsite',
-			'website',
-			'metadataX',
-			'X',
-			'x',
-			'metadataGithub',
-			'github',
-			'metadataTokenAddress'
-		]
-
-		for (const field of curatedFields) {
-			if (!processedKeys.has(field) && field in curatedMetadata) {
-				result.push({
-					metadataKey: field,
-					metadataValue: curatedMetadata[field as keyof typeof curatedMetadata] as string | null,
-					createdAt: null,
-					updatedAt: null
-				})
-			}
+	const defaultAvsFields = [
+		'metadataName',
+		'name',
+		'metadataDescription',
+		'description',
+		'metadataDiscord',
+		'discord',
+		'metadataLogo',
+		'logo',
+		'metadataTelegram',
+		'telegram',
+		'metadataWebsite',
+		'website',
+		'metadataX',
+		'X',
+		'x',
+		'metadataGithub',
+		'github',
+		'metadataTokenAddress',
+		'isVerified',
+		'isVisible'
+	]
+	for (const field of defaultAvsFields) {
+		// If curatedMetadata (from legacy table `AvsCuratedMetadata`) exists, use it as fallback if any of the default keys are missing
+		if (curatedMetadata && !processedKeys.has(field) && field in curatedMetadata) {
+			result.push({
+				metadataKey: field,
+				metadataValue: curatedMetadata[field as keyof typeof curatedMetadata] as string | null,
+				createdAt: null,
+				updatedAt: null
+			})
+		} else if (!processedKeys.has(field) && field in avs) {
+			// Else use the default data from the `Avs` table as fallback
+			result.push({
+				metadataKey: field,
+				metadataValue: avs[field as keyof typeof avs] as string | null,
+				createdAt: null,
+				updatedAt: null
+			})
 		}
 	}
 

--- a/packages/api/src/routes/avs/avsRoutes.ts
+++ b/packages/api/src/routes/avs/avsRoutes.ts
@@ -9,6 +9,8 @@ import {
 	getAVSRewardsEvents,
 	invalidateMetadata,
 	getAvsRegistrationEvents,
+	getAllMetadata,
+	getMetadata,
 	updateMetadata,
 	deleteMetadata,
 	deleteAllMetadata
@@ -22,6 +24,8 @@ const router = express.Router()
 router.get('/', routeCache.cacheSeconds(120), getAllAVS)
 
 router.get('/addresses', routeCache.cacheSeconds(120), getAllAVSAddresses)
+
+router.get('/get-all-metadata', routeCache.cacheSeconds(5), getAllMetadata) // Protected route for area-internal-dashboard
 
 router.get('/:address', routeCache.cacheSeconds(120), getAVS)
 
@@ -39,13 +43,15 @@ router.get(
 	getAvsRegistrationEvents
 )
 
-// Protected routes
-router.get('/:address/invalidate-metadata', routeCache.cacheSeconds(120), invalidateMetadata)
+// Protected AVS-specific routes custom for area-internal-dashboard
+router.get('/:address/get-metadata', routeCache.cacheSeconds(5), getMetadata)
 
 router.post('/:address/update-metadata', updateMetadata)
 
 router.post('/:address/delete-metadata', deleteMetadata)
 
 router.post('/:address/delete-all-metadata', deleteAllMetadata)
+
+router.get('/:address/invalidate-metadata', routeCache.cacheSeconds(120), invalidateMetadata) // Legacy
 
 export default router


### PR DESCRIPTION
To view AVS metadata, the area-internal-dashboard will now use the following routes
```
GET /avs/get-all-metadata

{
    "data": [
        {
            "address": "0xfc569b3b74e15cf48aa684144e072e839fd89380",
            "createdAt": "2024-11-05T06:47:47.000Z",
            "updatedAt": "2024-11-05T06:47:47.000Z",
            "additionalInfo": [
                {
                    "metadataKey": "metadataName",
                    "metadataValue": "Skate",
                    "createdAt": null,
                    "updatedAt": null
                },
               .
               .
            ]
        }
        .
        .
    ],
    "meta": {
        "total": 42,
        "skip": 0,
        "take": 1000
    }
}


GET /avs/:address/get-metadata

{
    "address": "0x42f15f9e4df4994317453477e80e24797cc1a929",
     .
     .
    "additionalInfo": [
        {
            "metadataKey": "metadataName",
            "metadataValue": "",
            "createdAt": null,
            "updatedAt": null
        },
        .
        .
    ]
}
```

instead of
```
GET /avs?withCuratedMetadata=true
GET /avs/:address?withCuratedMetadata=true
```

This effects the following changes:
- AVSs where `isVisible` is false are now accessible
- The GET routes are cached at 5s instead of 120s, so updates on the frontend are viewable immediately after submissions
- The `get-all-metadata` route has a hardcoded take so that all AVSs are retrieved in one shot, and they're sorted such that the "bookmarked" AVSs are first in the list

Note: No existing routes have any changes