### PR TITLE
Fix: Untangle Supabase refs and keys

### DIFF
--- a/packages/api/.env.example
+++ b/packages/api/.env.example
@@ -9,4 +9,6 @@ SUPABASE_SERVICE_ROLE_KEY = ""
 SUPABASE_PROJECT_REF = ""
 
 # Optional for dev environments. If ommitted, API Token restrictions are lifted and no comms with dev-portal DB.
+SUPABASE_EF_SERVICE_ROLE_KEY = ""
+SUPABASE_EF_PROJECT_REF = ""
 SUPABASE_EF_SELECTORS = "a:b:c"

--- a/packages/api/src/utils/authMiddleware.ts
+++ b/packages/api/src/utils/authMiddleware.ts
@@ -139,7 +139,7 @@ export const authenticator = async (req: Request, res: Response, next: NextFunct
 		const response = await fetch(`${functionUrl}/${apiToken}`, {
 			method: 'GET',
 			headers: {
-				Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`,
+				Authorization: `Bearer ${process.env.SUPABASE_EF_SERVICE_ROLE_KEY}`,
 				'Content-Type': 'application/json'
 			}
 		})
@@ -205,7 +205,7 @@ export async function refreshAuthStore() {
 			const response = await fetch(`${functionUrl}?skip=${skip}&take=${take}`, {
 				method: 'GET',
 				headers: {
-					Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`,
+					Authorization: `Bearer ${process.env.SUPABASE_EF_SERVICE_ROLE_KEY}`,
 					'Content-Type': 'application/json'
 				}
 			})
@@ -253,7 +253,11 @@ export async function refreshAuthStore() {
  *
  */
 export function isAuthRequired() {
-	return process.env.SUPABASE_EF_SELECTORS
+	return (
+		process.env.SUPABASE_EF_SERVICE_ROLE_KEY &&
+		process.env.SUPABASE_EF_PROJECT_REF &&
+		process.env.SUPABASE_EF_SELECTORS
+	)
 }
 
 /**
@@ -266,7 +270,7 @@ export function isAuthRequired() {
  * @returns
  */
 export function constructEfUrl(index: number) {
-	const projectRef = process.env.SUPABASE_PROJECT_REF || null
+	const projectRef = process.env.SUPABASE_EF_PROJECT_REF || null
 	const functionSelector = process.env.SUPABASE_EF_SELECTORS?.split(':')[index - 1] || null
 
 	return projectRef && functionSelector

--- a/packages/api/src/utils/requestsUpdateManager.ts
+++ b/packages/api/src/utils/requestsUpdateManager.ts
@@ -103,7 +103,7 @@ class RequestsUpdateManager {
 		const response = await fetch(url, {
 			method: 'POST',
 			headers: {
-				Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`,
+				Authorization: `Bearer ${process.env.SUPABASE_EF_SERVICE_ROLE_KEY}`,
 				'Content-Type': 'application/json'
 			},
 			body: JSON.stringify(data.map((payload) => payload.data))


### PR DESCRIPTION
### Issue
On addition of the AVS Curated Metadata upgrade, there is a mix-up in the usage of 2 env vars `SUPABASE_SERVICE_ROLE_KEY` and `SUPABASE_PROJECT_REF`.

- The original usage was to use the service role key & project ref values of the Dev Portal DB in order to handle user auth
- However, we require now require these values of the EE Backend DB too, to process image uploads
- This created a mix-up in wrongly using the Dev Portal's service role key & project ref values to process image uploads
- The dev-main DB doesn't use auth and hence the issue went undetected

### Fix
- The Dev Portal DB values are now set as `SUPABASE_EF_SERVICE_ROLE_KEY` and `SUPABASE_EF_PROJECT_REF` (adding `EF`, keeping in line with the existing terminology of "edge-function" related vars)
- The EE Backend values are set as `SUPABASE_SERVICE_ROLE_KEY` and `SUPABASE_PROJECT_REF`
- All instances of usage have been updated to use the newly name env vars
- The check for `isAuthRequired()` now checks for all 3 auth-related env vars, as it did before the Curated Metadata upgrade

Note: On deploying the release with this fix, on GCP we need to:
- update the names of existing env vars `SUPABASE_SERVICE_ROLE_KEY` -> `SUPABASE_EF_SERVICE_ROLE_KEY` & `SUPABASE_PROJECT_REF` -> `SUPABASE_EF_PROJECT_REF` since these are of the Dev Portal DB
- add 2 new env vars `SUPABASE_SERVICE_ROLE_KEY` & `SUPABASE_PROJECT_REF` of the EE Backend DB