### PR TITLE
Feat: AdditionalInfo deprecates CuratedMetadata

### DIFF
--- a/packages/api/src/routes/avs/avsController.ts
+++ b/packages/api/src/routes/avs/avsController.ts
@@ -1527,17 +1527,6 @@ function getAdditionalInfo(avs: any) {
 		updatedAt: Date | null
 	}> = []
 
-	for (const info of additionalInfo) {
-		result.push({
-			metadataKey: info.metadataKey,
-			metadataValue: info.metadataContent,
-			createdAt: info.createdAt,
-			updatedAt: info.updatedAt
-		})
-
-		processedKeys.add(info.metadataKey)
-	}
-
 	const defaultAvsFields = [
 		'metadataName',
 		'metadataDescription',
@@ -1547,9 +1536,7 @@ function getAdditionalInfo(avs: any) {
 		'metadataWebsite',
 		'metadataX',
 		'metadataGithub',
-		'metadataTokenAddress',
-		'isVerified',
-		'isVisible'
+		'metadataTokenAddress'
 	]
 	for (const field of defaultAvsFields) {
 		if (field in avs) {
@@ -1561,6 +1548,17 @@ function getAdditionalInfo(avs: any) {
 				updatedAt: null
 			})
 		}
+	}
+
+	for (const info of additionalInfo) {
+		result.push({
+			metadataKey: info.metadataKey,
+			metadataValue: info.metadataContent,
+			createdAt: info.createdAt,
+			updatedAt: info.updatedAt
+		})
+
+		processedKeys.add(info.metadataKey)
 	}
 
 	return result

--- a/packages/api/src/routes/avs/avsController.ts
+++ b/packages/api/src/routes/avs/avsController.ts
@@ -235,7 +235,7 @@ export async function getAllAVSAddresses(req: Request, res: Response) {
 
 /**
  * Function for route /avs/get-all-metadata
- * Protected route to return all AVS metadata, customized for admin access via area-internal-dashboard
+ * Protected route to return all Avs metadata from the new `AvsAdditionalInfo`, instead of from the legacy `AvsCuratedMetadata`
  * Differs from using `withMetadata` flag -- returns all Avs regardless of `isVisible` or existence of `curatedMetadata`, and with "bookmarked" ones first
  *
  * @param req
@@ -253,8 +253,7 @@ export async function getAllMetadata(req: Request, res: Response) {
 		const take = 1000
 		const allAvs = await prisma.avs.findMany({
 			include: {
-				additionalInfo: true,
-				curatedMetadata: true
+				additionalInfo: true
 			},
 			skip,
 			take
@@ -265,7 +264,6 @@ export async function getAllMetadata(req: Request, res: Response) {
 			address: avs.address,
 			createdAt: avs.createdAt,
 			updatedAt: avs.updatedAt,
-			curatedMetadata: avs.curatedMetadata,
 			additionalInfo: getAdditionalInfo(avs)
 		}))
 
@@ -359,7 +357,7 @@ export async function getAVS(req: Request, res: Response) {
 
 		res.send({
 			...avs,
-			curatedMetadata: withCuratedMetadata ? avs.curatedMetadata : undefined,
+			curatedMetadata: withCuratedMetadata ? avs.curatedMetadata : undefined, // Legacy retained
 			additionalInfo: withCuratedMetadata ? getAdditionalInfo(avs) : undefined,
 			shares,
 			totalOperators: avs.totalOperators,
@@ -906,7 +904,7 @@ export async function getAvsRegistrationEvents(req: Request, res: Response) {
 
 /**
  * Function for route /avs/:address/get-metadata
- * Protected route to return a given AVS metadata, customized for admin access via area-internal-dashboard
+ * Protected route to return a given Avs metadata from the new `AvsAdditionalInfo`, instead of from the legacy `AvsCuratedMetadata`
  * Differs from using `withMetadata` flag -- returns Avs regardless of `isVisible` or existence of `curatedMetadata`
  *
  * @param req
@@ -931,15 +929,13 @@ export async function getMetadata(req: Request, res: Response) {
 		const avs = await prisma.avs.findUniqueOrThrow({
 			where: { address: address.toLowerCase() },
 			include: {
-				additionalInfo: true,
-				curatedMetadata: true
+				additionalInfo: true
 			}
 		})
 
 		res.send({
 			...avs,
-			additionalInfo: getAdditionalInfo(avs),
-			curatedMetadata: undefined
+			additionalInfo: getAdditionalInfo(avs)
 		})
 	} catch (error) {
 		handleAndReturnErrorResponse(req, res, error)

--- a/packages/api/src/routes/avs/avsController.ts
+++ b/packages/api/src/routes/avs/avsController.ts
@@ -27,7 +27,8 @@ import {
 import { MinTvlQuerySchema } from '../../schema/zod/schemas/minTvlQuerySchema'
 import {
 	AvsAdditionalInfoSchema,
-	AvsAdditionalInfoKeys
+	AvsAdditionalInfoKeys,
+	defaultAvsFields
 } from '../../schema/zod/schemas/updateAvsMetadata'
 import { isAuthRequired } from '../../utils/authMiddleware'
 import { WithTrailingApySchema } from '../../schema/zod/schemas/withTrailingApySchema'
@@ -1523,17 +1524,6 @@ function getAdditionalInfo(avs: any) {
 		updatedAt: Date | null
 	}> = []
 
-	const defaultAvsFields = [
-		'metadataName',
-		'metadataDescription',
-		'metadataDiscord',
-		'metadataLogo',
-		'metadataTelegram',
-		'metadataWebsite',
-		'metadataX',
-		'metadataGithub',
-		'metadataTokenAddress'
-	]
 	for (const field of defaultAvsFields) {
 		if (field in avs) {
 			// Load up the default keys from the `Avs` table

--- a/packages/api/src/schema/zod/schemas/updateAvsMetadata.ts
+++ b/packages/api/src/schema/zod/schemas/updateAvsMetadata.ts
@@ -1,12 +1,31 @@
 import z from '..'
 
+export const defaultAvsFields = [
+	'metadataName',
+	'metadataDescription',
+	'metadataDiscord',
+	'metadataLogo',
+	'metadataTelegram',
+	'metadataWebsite',
+	'metadataX',
+	'metadataGithub',
+	'metadataTokenAddress'
+]
+
 export const AvsAdditionalInfoSchema = z.object({
 	items: z.array(
 		z.union([
 			// For storing strings
 			z.object({
 				contentType: z.literal('application/json'),
-				metadataKey: z.string().min(1, 'metadataKey cannot be empty'),
+				metadataKey: z
+					.string()
+					.min(1, 'metadataKey cannot be empty')
+					.refine((key) => !defaultAvsFields.includes(key), {
+						message: `metadataKey cannot be one of the reserved fields: ${defaultAvsFields.join(
+							', '
+						)}`
+					}),
 				metadataContent: z.string().nullable()
 			}),
 			// For storing image media
@@ -32,4 +51,11 @@ export const AvsAdditionalInfoSchema = z.object({
 	)
 })
 
-export const AvsAdditionalInfoKeys = z.array(z.string().min(1, 'metadataKeys cannot be empty'))
+export const AvsAdditionalInfoKeys = z.array(
+	z
+		.string()
+		.min(1, 'metadataKeys cannot be empty')
+		.refine((key) => !defaultAvsFields.includes(key), {
+			message: `metadataKey cannot be one of the reserved fields: ${defaultAvsFields.join(', ')}`
+		})
+)


### PR DESCRIPTION
The new curated metadata routes [`/get-all-metadata` and `/:address/get-metadata`] do not acknowledge the `AvsCuratedMetadata` table anymore. They now:
- Return only data from `AvsAdditonalInfoTable` in its established format
```
{
    "metadataKey": "",
    "metadataValue": "",
    "createdAt": "",
    "updatedAt": ""
}
```
- Take the following default fields from the `Avs` table directly. These are uneditable from the area-internal-dashboard
```
const defaultAvsFields = [
    'metadataName',
    'metadataDescription',
    'metadataDiscord',
    'metadataLogo',
    'metadataTelegram',
    'metadataWebsite',
    'metadataX',
    'metadataGithub',
    'metadataTokenAddress'
]
```
- `/get-all-metadata` continues to sort the response placing the "bookmarked" AVSs first

Also, the `/:address/update-metadata` & `/:address/delete-metadata` routes do not accept any of the above default fields as inputs:
- These fields hence cannot be updated or deleted via API
- The area-internal-dashboard will need to use a new set of data for these fields using the "curated-" prefix instead of the "metadata-" prefix
- The area-frontend can then implement logic like "if curated-<key> does not exist then use metadata-<key>"

Note: Using the `?withCuratedMetadata=true` flag on the public routes still return the legacy `curatedMetadata` along with the new `additionalInfo`. In case EE frontend chooses to deprecate the use of `AvsCuratedMetadata` (so that the area-internal-dashboard updates can apply there), the `AvsFilterQuery` must be updated to check `isVisible` from `AvsAdditionalInfo` instead of `AvsCuratedMetadata`!