### PR TITLE
Feat: Allow search to access additional info

### DIFF
--- a/packages/api/src/schema/zod/schemas/searchByTextQuery.ts
+++ b/packages/api/src/schema/zod/schemas/searchByTextQuery.ts
@@ -33,7 +33,8 @@ export const SearchByTextQuerySchema = z
 				return value.trim().split(/\s+/).join('&') // Replace spaces with '&' for tsquery compatibility
 			})
 			.describe('Case-insensitive search query')
-			.openapi({ example: 'eigen' })
+			.openapi({ example: 'eigen' }),
+		legacy: z.enum(['true', 'false']).default('true').openapi({ example: 'false' })
 	})
 	.refine(
 		(data) => {


### PR DESCRIPTION
Added a flag `legacy: 'true' | 'false'` to the search the route `/avs/addresses?searchByText=` which when set to `false` accesses values for name, logo and isVisible from the `AvsAdditionalInfo` table, and hence corresponds to area-internal-dashboard settings.

The flag is additional and optional, there is no breaking change or expected behaviour change on ee-frontend.