### PR TITLE
Add Apy response for non rewarding AVSs/Strategies

### DIFF
--- a/packages/api/src/routes/avs/avsController.ts
+++ b/packages/api/src/routes/avs/avsController.ts
@@ -1445,6 +1445,19 @@ async function calculateAvsApy(avs: any, withTrailingApy: boolean = false) {
 			const strategyTvl = tvlStrategiesEth[strategyAddressLower] || 0
 			if (strategyTvl === 0) continue
 
+			// Initialize strategyApyMap with baseApy
+			const initialStrategyData = {
+				apy: 0,
+				baseApy: baseApyMap.get(strategyAddressLower) || 0,
+				trailingApy7d: withTrailingApy ? 0 : undefined,
+				trailingApy30d: withTrailingApy ? 0 : undefined,
+				trailingApy3m: withTrailingApy ? 0 : undefined,
+				trailingApy6m: withTrailingApy ? 0 : undefined,
+				trailingApy1y: withTrailingApy ? 0 : undefined,
+				tokens: new Map<string, number>()
+			}
+			strategyApyMap.set(strategyAddressLower, initialStrategyData)
+
 			const tokenApyMap: Map<string, number> = new Map()
 			const tokenRewards: Map<
 				string,

--- a/packages/api/src/utils/baseApys.ts
+++ b/packages/api/src/utils/baseApys.ts
@@ -42,18 +42,6 @@ export async function fetchBaseApys(): Promise<BaseApy[]> {
 
 	// Process each strategy
 	for (const strategy of strategies) {
-		const dlPoolId = tokenPoolIdMap.get(strategy.underlyingToken.toLowerCase())
-		if (!dlPoolId) {
-			// No pool ID, use default APY
-			baseApys.push({
-				poolId: tokenPoolIdMap.get(strategy.underlyingToken.toLowerCase()) || '',
-				strategyAddress: strategy.address,
-				tokenAddress: strategy.underlyingToken.toLowerCase(),
-				apy: 0
-			})
-			continue
-		}
-
 		const cacheKey = `apy_${strategy.address}`
 		const cachedApy = await cacheStore.get(cacheKey)
 
@@ -64,6 +52,57 @@ export async function fetchBaseApys(): Promise<BaseApy[]> {
 				strategyAddress: strategy.address,
 				tokenAddress: strategy.underlyingToken.toLowerCase(),
 				apy: cachedApy
+			})
+			continue
+		}
+
+		// Check if strategy is Beacon Chain
+		if (strategy.address.toLowerCase() === '0xbeac0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeebeac0') {
+			try {
+				// Fetch APR from Beaconcha.in API
+				const response = await fetch('https://beaconcha.in/api/v1/ethstore/latest')
+
+				if (!response.ok) {
+					throw new Error(`Beaconcha.in API error: ${response.statusText}`)
+				}
+
+				const data = await response.json()
+				if (data.status !== 'OK' || !data.data || !data.data.apr) {
+					throw new Error(`Invalid APR data from Beaconcha.in: ${JSON.stringify(data)}`)
+				}
+
+				const apyBase = Number(data.data.apr) * 100 // Convert APR to percentage
+
+				// Cache APY
+				const ttlMillis = maxHours * 3_600_000 // Convert hours to milliseconds
+				await cacheStore.set(cacheKey, apyBase, ttlMillis)
+
+				baseApys.push({
+					poolId: '', // No dlPoolId for native staking
+					strategyAddress: strategy.address,
+					tokenAddress: strategy.underlyingToken.toLowerCase(),
+					apy: apyBase
+				})
+			} catch (error) {
+				console.error(`Error fetching APR for Beacon Chain staking:`, error)
+				baseApys.push({
+					poolId: '',
+					strategyAddress: strategy.address,
+					tokenAddress: strategy.underlyingToken.toLowerCase(),
+					apy: 0
+				})
+			}
+			continue
+		}
+
+		const dlPoolId = tokenPoolIdMap.get(strategy.underlyingToken.toLowerCase())
+		if (!dlPoolId) {
+			// No pool ID, use default APY
+			baseApys.push({
+				poolId: tokenPoolIdMap.get(strategy.underlyingToken.toLowerCase()) || '',
+				strategyAddress: strategy.address,
+				tokenAddress: strategy.underlyingToken.toLowerCase(),
+				apy: 0
 			})
 			continue
 		}


### PR DESCRIPTION
Adds the following response for AVSs/Strategies with no rewards
when withRewards = true 
```
{
                "strategyAddress": "0xae60d8180437b5c34bb956822ac2710972584473",
                "apy": 0,
                "baseApy": 3.06194,
                "tokens": []
}
```

when withTrailingApy = true 
```
{
                "strategyAddress": "0xae60d8180437b5c34bb956822ac2710972584473",
                "apy": 0,
                "baseApy": 3.06194,
                "trailingApy7d": 0,
                "trailingApy30d": 0,
                "trailingApy3m": 0,
                "trailingApy6m": 0,
                "trailingApy1y": 0,
                "tokens": []
}
```

Also, adds baseApy for beacon-chain strategy using the Beaconcha.in API