### PR TITLE
[Feat] - Add seeders for Redistributable Slashing and Operator Set Rewards

### DIFF
--- a/packages/prisma/migrations/20250830063911_include_restributable_slashing/migration.sql
+++ b/packages/prisma/migrations/20250830063911_include_restributable_slashing/migration.sql
@@ -1,0 +1,23 @@
+-- AlterTable
+ALTER TABLE "OperatorSet" ADD COLUMN     "redistributionRecipient" TEXT;
+
+-- CreateTable
+CREATE TABLE "EventLogs_RedistributionAddressSet" (
+    "address" TEXT NOT NULL,
+    "transactionHash" TEXT NOT NULL,
+    "transactionIndex" INTEGER NOT NULL,
+    "blockNumber" BIGINT NOT NULL,
+    "blockHash" TEXT NOT NULL,
+    "blockTime" TIMESTAMP(3) NOT NULL,
+    "avs" TEXT NOT NULL,
+    "operatorSetId" BIGINT NOT NULL,
+    "redistributionRecipient" TEXT NOT NULL,
+
+    CONSTRAINT "EventLogs_RedistributionAddressSet_pkey" PRIMARY KEY ("transactionHash","transactionIndex")
+);
+
+-- CreateIndex
+CREATE INDEX "EventLogs_RedistributionAddressSet_avs_operatorSetId_idx" ON "EventLogs_RedistributionAddressSet"("avs", "operatorSetId");
+
+-- CreateIndex
+CREATE INDEX "EventLogs_RedistributionAddressSet_blockNumber_idx" ON "EventLogs_RedistributionAddressSet"("blockNumber");

--- a/packages/prisma/migrations/20250830064011_include_operartor_set_rewards/migration.sql
+++ b/packages/prisma/migrations/20250830064011_include_operartor_set_rewards/migration.sql
@@ -1,0 +1,57 @@
+-- CreateTable
+CREATE TABLE "EventLogs_OperatorDirectedOperatorSetRewardsSubmission" (
+    "address" TEXT NOT NULL,
+    "transactionHash" TEXT NOT NULL,
+    "transactionIndex" INTEGER NOT NULL,
+    "blockNumber" BIGINT NOT NULL,
+    "blockHash" TEXT NOT NULL,
+    "blockTime" TIMESTAMP(3) NOT NULL,
+    "caller" TEXT NOT NULL,
+    "avs" TEXT NOT NULL,
+    "operatorSetId" BIGINT NOT NULL,
+    "operatorDirectedRewardsSubmissionHash" TEXT NOT NULL,
+    "submissionNonce" BIGINT NOT NULL,
+    "operatorDirectedRewardsSubmission_token" TEXT NOT NULL,
+    "operatorDirectedRewardsSubmission_startTimestamp" BIGINT NOT NULL,
+    "operatorDirectedRewardsSubmission_duration" INTEGER NOT NULL,
+    "operatorDirectedRewardsSubmission_description" TEXT NOT NULL,
+    "strategiesAndMultipliers_strategies" TEXT[],
+    "strategiesAndMultipliers_multipliers" TEXT[],
+    "operatorRewards_operators" TEXT[],
+    "operatorRewards_amounts" TEXT[],
+
+    CONSTRAINT "EventLogs_OperatorDirectedOperatorSetRewardsSubmission_pkey" PRIMARY KEY ("transactionHash","transactionIndex")
+);
+
+-- CreateTable
+CREATE TABLE "OperatorDirectedOperatorSetRewardsSubmission" (
+    "id" SERIAL NOT NULL,
+    "submissionNonce" BIGINT NOT NULL,
+    "operatorDirectedRewardsSubmissionHash" TEXT NOT NULL,
+    "avsAddress" TEXT NOT NULL,
+    "operatorAddress" TEXT NOT NULL,
+    "operatorSetId" BIGINT NOT NULL,
+    "strategyAddress" TEXT NOT NULL,
+    "multiplier" DECIMAL(78,0) NOT NULL DEFAULT 0,
+    "token" TEXT NOT NULL,
+    "amount" DECIMAL(78,0) NOT NULL DEFAULT 0,
+    "startTimestamp" BIGINT NOT NULL,
+    "duration" INTEGER NOT NULL,
+    "description" TEXT NOT NULL,
+    "createdAtBlock" BIGINT NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OperatorDirectedOperatorSetRewardsSubmission_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ODOSRS_address_idx" ON "EventLogs_OperatorDirectedOperatorSetRewardsSubmission"("address");
+
+-- CreateIndex
+CREATE INDEX "ODOSRS_blockNumber_idx" ON "EventLogs_OperatorDirectedOperatorSetRewardsSubmission"("blockNumber");
+
+-- CreateIndex
+CREATE INDEX "ODOSRS_blockTime_idx" ON "EventLogs_OperatorDirectedOperatorSetRewardsSubmission"("blockTime");
+
+-- AddForeignKey
+ALTER TABLE "OperatorDirectedOperatorSetRewardsSubmission" ADD CONSTRAINT "OperatorDirectedOperatorSetRewardsSubmission_avsAddress_op_fkey" FOREIGN KEY ("avsAddress", "operatorSetId", "operatorAddress") REFERENCES "AvsOperatorSet"("avsAddress", "operatorSetId", "operatorAddress") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -822,6 +822,37 @@ model EventLogs_OperatorDirectedAVSRewardsSubmission {
   @@index([blockTime])
 }
 
+model EventLogs_OperatorDirectedOperatorSetRewardsSubmission {
+  address String
+
+  transactionHash  String
+  transactionIndex Int
+  blockNumber      BigInt
+  blockHash        String
+  blockTime        DateTime
+
+  caller                                String
+  avs                                   String
+  operatorSetId                         BigInt
+  operatorDirectedRewardsSubmissionHash String
+  submissionNonce                       BigInt
+
+  operatorDirectedRewardsSubmission_token          String
+  operatorDirectedRewardsSubmission_startTimestamp BigInt
+  operatorDirectedRewardsSubmission_duration       Int
+  operatorDirectedRewardsSubmission_description    String
+
+  strategiesAndMultipliers_strategies  String[]
+  strategiesAndMultipliers_multipliers String[]
+  operatorRewards_operators            String[]
+  operatorRewards_amounts              String[]
+
+  @@id([transactionHash, transactionIndex])
+  @@index([address], map: "ODOSRS_address_idx")
+  @@index([blockNumber], map: "ODOSRS_blockNumber_idx")
+  @@index([blockTime], map: "ODOSRS_blockTime_idx")
+}
+
 model EventLogs_OperatorAVSSplitBipsSet {
   address String
 
@@ -1176,6 +1207,24 @@ model EventLogs_DepositScalingFactorUpdated {
   @@index([blockNumber])
 }
 
+model EventLogs_RedistributionAddressSet {
+  address String
+
+  transactionHash  String
+  transactionIndex Int
+  blockNumber      BigInt
+  blockHash        String
+  blockTime        DateTime
+
+  avs String
+  operatorSetId BigInt
+  redistributionRecipient String
+
+  @@id([transactionHash, transactionIndex])
+  @@index([blockNumber])
+  @@index([avs,operatorSetId])
+}
+
 model OperatorSet {
   avs      Avs      @relation(fields: [avsAddress], references: [address])
   avsAddress        String
@@ -1189,6 +1238,8 @@ model OperatorSet {
   updatedAtBlock BigInt   @default(0)
   createdAt      DateTime @default(now())
   updatedAt      DateTime @default(now())
+
+  redistributionRecipient String?
 
   @@id([avsAddress, operatorSetId])
   @@index([avsAddress])
@@ -1206,6 +1257,7 @@ model AvsOperatorSet {
   slashableUntil     BigInt
 
   slashedRecords    AvsOperatorSlashed[]
+  rewards           OperatorDirectedOperatorSetRewardsSubmission[]
 
   createdAtBlock BigInt   @default(0)
   updatedAtBlock BigInt   @default(0)
@@ -1239,6 +1291,29 @@ model AvsAllocation {
     @@index([avsAddress])
     @@index([operatorAddress])
     @@index([avsAddress, operatorSetId])
+}
+
+model OperatorDirectedOperatorSetRewardsSubmission {
+  id       Int      @id @default(autoincrement())
+  avsOperatorSet    AvsOperatorSet @relation(fields: [avsAddress, operatorSetId, operatorAddress ], references: [avsAddress, operatorSetId, operatorAddress])
+
+  submissionNonce                       BigInt
+  operatorDirectedRewardsSubmissionHash String
+
+  avsAddress      String
+  operatorAddress String
+  operatorSetId   BigInt
+
+  strategyAddress String
+  multiplier      Decimal @default(0) @db.Decimal(78, 0)
+  token           String
+  amount          Decimal @default(0) @db.Decimal(78, 0)
+  startTimestamp  BigInt
+  duration        Int
+  description     String
+
+  createdAtBlock BigInt   @default(0)
+  createdAt      DateTime @default(now())
 }
 
 model AvsOperatorSlashed {

--- a/packages/seeder/src/events/seedLogsOperatorDirectedOperatorSetRewardsSubmission.ts
+++ b/packages/seeder/src/events/seedLogsOperatorDirectedOperatorSetRewardsSubmission.ts
@@ -1,0 +1,138 @@
+import prisma from '@prisma/client'
+import { parseAbiItem } from 'viem'
+import { getEigenContracts } from '../data/address'
+import { getViemClient } from '../utils/viemClient'
+import {
+	bulkUpdateDbTransactions,
+	fetchLastSyncBlock,
+	getBlockDataFromDb,
+	LogsUpdateMetadata,
+	loopThroughBlocks
+} from '../utils/seeder'
+import { getPrismaClient } from '../utils/prismaClient'
+
+const blockSyncKeyLogs = 'lastSyncedBlock_logs_operatorDirectedOperatorSetRewardsSubmission'
+
+export async function seedLogsOperatorDirectedOperatorSetRewardsSubmission(
+	toBlock?: bigint,
+	fromBlock?: bigint
+): Promise<LogsUpdateMetadata> {
+	const viemClient = getViemClient()
+	const prismaClient = getPrismaClient()
+
+	const firstBlock = fromBlock ? fromBlock : await fetchLastSyncBlock(blockSyncKeyLogs)
+	const lastBlock = toBlock ? toBlock : await viemClient.getBlockNumber()
+
+	let isUpdated = false
+	let updatedCount = 0
+
+	await loopThroughBlocks(firstBlock, lastBlock, async (fromBlock, toBlock) => {
+		const blockData = await getBlockDataFromDb(fromBlock, toBlock)
+		try {
+			const dbTransactions: any[] = []
+			const logsOperatorDirected: prisma.EventLogs_OperatorDirectedOperatorSetRewardsSubmission[] =
+				[]
+
+			const logs = await viemClient.getLogs({
+				address: getEigenContracts().RewardsCoordinator,
+				events: [
+					parseAbiItem([
+						'event OperatorDirectedOperatorSetRewardsSubmissionCreated(address indexed caller,bytes32 indexed operatorDirectedRewardsSubmissionHash,OperatorSet operatorSet,uint256 submissionNonce,OperatorDirectedRewardsSubmission operatorDirectedRewardsSubmission)',
+						'struct OperatorSet {address avs;uint32 id;}',
+						'struct OperatorDirectedRewardsSubmission { StrategyAndMultiplier[] strategiesAndMultipliers; address token; OperatorReward[] operatorRewards; uint32 startTimestamp; uint32 duration; string description; }',
+						'struct StrategyAndMultiplier { address strategy; uint96 multiplier; }',
+						'struct OperatorReward { address operator; uint256 amount; }'
+					])
+				],
+				fromBlock,
+				toBlock
+			})
+
+			for (const l in logs) {
+				const log = logs[l]
+
+				const strategies: string[] = []
+				const multipliers: string[] = []
+				const operatorRewardsOperators: string[] = []
+				const operatorRewardsAmounts: string[] = []
+
+				const ods = log.args.operatorDirectedRewardsSubmission
+
+				// Process strategies and multipliers
+				if (ods?.strategiesAndMultipliers) {
+					for (const sm of ods.strategiesAndMultipliers) {
+						strategies.push(sm.strategy)
+						multipliers.push(sm.multiplier.toString())
+					}
+				}
+
+				// Process operator rewards
+				if (ods?.operatorRewards) {
+					for (const orw of ods.operatorRewards) {
+						operatorRewardsOperators.push(String(orw.operator))
+						operatorRewardsAmounts.push(orw.amount.toString())
+					}
+				}
+
+				logsOperatorDirected.push({
+					address: log.address,
+					transactionHash: log.transactionHash,
+					transactionIndex: log.logIndex,
+					blockNumber: BigInt(log.blockNumber),
+					blockHash: log.blockHash,
+					blockTime: blockData.get(log.blockNumber) || new Date(0),
+
+					caller: String(log.args.caller),
+					avs: String(log.args.operatorSet?.avs),
+					operatorSetId: BigInt(log.args.operatorSet?.id || 0),
+					submissionNonce: BigInt(log.args.submissionNonce || 0),
+					operatorDirectedRewardsSubmissionHash: String(
+						log.args.operatorDirectedRewardsSubmissionHash
+					),
+
+					operatorDirectedRewardsSubmission_token: String(ods?.token),
+					operatorDirectedRewardsSubmission_startTimestamp: BigInt(ods?.startTimestamp || 0),
+					operatorDirectedRewardsSubmission_duration: Number(ods?.duration),
+					operatorDirectedRewardsSubmission_description: String(ods?.description),
+
+					strategiesAndMultipliers_strategies: strategies,
+					strategiesAndMultipliers_multipliers: multipliers,
+					operatorRewards_operators: operatorRewardsOperators,
+					operatorRewards_amounts: operatorRewardsAmounts
+				})
+			}
+
+			dbTransactions.push(
+				prismaClient.eventLogs_OperatorDirectedOperatorSetRewardsSubmission.createMany({
+					data: logsOperatorDirected,
+					skipDuplicates: true
+				})
+			)
+
+			// Store last synced block
+			dbTransactions.push(
+				prismaClient.settings.upsert({
+					where: { key: blockSyncKeyLogs },
+					update: { value: Number(toBlock) },
+					create: { key: blockSyncKeyLogs, value: Number(toBlock) }
+				})
+			)
+
+			// Update database
+			const seedLength = logsOperatorDirected.length
+
+			await bulkUpdateDbTransactions(
+				dbTransactions,
+				`[Logs] Operator Directed Operator Set Rewards Submission from: ${fromBlock} to: ${toBlock} size: ${seedLength}`
+			)
+
+			isUpdated = true
+			updatedCount += seedLength
+		} catch {}
+	})
+
+	return {
+		isUpdated,
+		updatedCount
+	}
+}

--- a/packages/seeder/src/events/seedLogsRedistributionAddressSet.ts
+++ b/packages/seeder/src/events/seedLogsRedistributionAddressSet.ts
@@ -1,0 +1,104 @@
+import prisma from '@prisma/client'
+import { parseAbiItem } from 'viem'
+import { getEigenContracts } from '../data/address'
+import { getViemClient } from '../utils/viemClient'
+import {
+	bulkUpdateDbTransactions,
+	fetchLastSyncBlock,
+	getBlockDataFromDb,
+	loopThroughBlocks,
+	LogsUpdateMetadata
+} from '../utils/seeder'
+import { getPrismaClient } from '../utils/prismaClient'
+
+const blockSyncKeyLogs = 'lastSyncedBlock_logs_redistributionAddress'
+
+/**
+ * Utility function to seed event logs
+ *
+ * @param fromBlock
+ * @param toBlock
+ */
+export async function seedLogsRedistributionAddressSet(
+	toBlock?: bigint,
+	fromBlock?: bigint
+): Promise<LogsUpdateMetadata> {
+	const viemClient = getViemClient()
+	const prismaClient = getPrismaClient()
+
+	const firstBlock = fromBlock ? fromBlock : await fetchLastSyncBlock(blockSyncKeyLogs)
+	const lastBlock = toBlock ? toBlock : await viemClient.getBlockNumber()
+
+	let isUpdated = false
+	let updatedCount = 0
+
+	// Loop through evm logs
+	await loopThroughBlocks(firstBlock, lastBlock, async (fromBlock, toBlock) => {
+		const blockData = await getBlockDataFromDb(fromBlock, toBlock)
+
+		try {
+			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+			const dbTransactions: any[] = []
+			const logsRedistributionAddressSet: prisma.EventLogs_RedistributionAddressSet[] = []
+
+			const logs = await viemClient.getLogs({
+				address: getEigenContracts().AllocationManager,
+				event: parseAbiItem([
+					'event RedistributionAddressSet(OperatorSet operatorSet, address redistributionRecipient)',
+					'struct OperatorSet {address avs;uint32 id;}'
+				]),
+				fromBlock,
+				toBlock
+			})
+
+			// Setup a list containing event data
+			for (const l in logs) {
+				const log = logs[l]
+
+				logsRedistributionAddressSet.push({
+					address: log.address,
+					transactionHash: log.transactionHash,
+					transactionIndex: log.logIndex,
+					blockNumber: BigInt(log.blockNumber),
+					blockHash: log.blockHash,
+					blockTime: blockData.get(log.blockNumber) || new Date(0),
+					avs: String(log.args.operatorSet?.avs),
+					operatorSetId: BigInt(log.args.operatorSet?.id || 0),
+					redistributionRecipient: String(log.args.redistributionRecipient)
+				})
+			}
+
+			dbTransactions.push(
+				prismaClient.eventLogs_RedistributionAddressSet.createMany({
+					data: logsRedistributionAddressSet,
+					skipDuplicates: true
+				})
+			)
+
+			// Store last synced block
+			dbTransactions.push(
+				prismaClient.settings.upsert({
+					where: { key: blockSyncKeyLogs },
+					update: { value: Number(toBlock) },
+					create: { key: blockSyncKeyLogs, value: Number(toBlock) }
+				})
+			)
+
+			// Update database
+			const seedLength = logsRedistributionAddressSet.length
+
+			await bulkUpdateDbTransactions(
+				dbTransactions,
+				`[Logs] Redistribution Address Set from: ${fromBlock} to: ${toBlock} size: ${seedLength}`
+			)
+
+			isUpdated = true
+			updatedCount += seedLength
+		} catch (error) {}
+	})
+
+	return {
+		isUpdated,
+		updatedCount
+	}
+}

--- a/packages/seeder/src/seedOperatorDirectedOperatorSetRewards.ts
+++ b/packages/seeder/src/seedOperatorDirectedOperatorSetRewards.ts
@@ -1,0 +1,115 @@
+import prisma from '@prisma/client'
+import { getPrismaClient } from './utils/prismaClient'
+import {
+	bulkUpdateDbTransactions,
+	fetchLastSyncBlock,
+	loopThroughBlocks,
+	saveLastSyncBlock
+} from './utils/seeder'
+import { distributeAmount } from './utils/amounts'
+
+const blockSyncKey = 'lastSyncedBlock_operatorDirectedOperatorSetRewards'
+const blockSyncKeyLogs = 'lastSyncedBlock_logs_operatorDirectedOperatorSetRewardsSubmission'
+
+export async function seedOperatorDirectedOperatorSetRewards(toBlock?: bigint, fromBlock?: bigint) {
+	const prismaClient = getPrismaClient()
+	const operatorDirectedRewardSubmissionList: Omit<
+		prisma.OperatorDirectedOperatorSetRewardsSubmission,
+		'id'
+	>[] = []
+
+	const existingAvs = await prismaClient.avs.findMany({ select: { address: true } })
+	const existingAvsSet = new Set(existingAvs.map((avs) => avs.address.toLowerCase()))
+
+	const existingOperators = await prismaClient.operator.findMany({ select: { address: true } })
+	const existingOperatorsSet = new Set(existingOperators.map((op) => op.address.toLowerCase()))
+
+	const firstBlock = fromBlock ? fromBlock : await fetchLastSyncBlock(blockSyncKey)
+	const lastBlock = toBlock ? toBlock : await fetchLastSyncBlock(blockSyncKeyLogs)
+
+	// Bail early if there is no block diff to sync
+	if (lastBlock - firstBlock <= 0) {
+		console.log(
+			`[In Sync] [Data] Operator Directed Operator Set Rewards from: ${firstBlock} to: ${lastBlock}`
+		)
+		return
+	}
+
+	await loopThroughBlocks(firstBlock, lastBlock, async (fromBlock, toBlock) => {
+		const logs = await prismaClient.eventLogs_OperatorDirectedOperatorSetRewardsSubmission.findMany(
+			{
+				where: {
+					blockNumber: {
+						gt: fromBlock,
+						lte: toBlock
+					}
+				}
+			}
+		)
+
+		for (const log of logs) {
+			const avsAddress = log.avs.toLowerCase()
+			if (!existingAvsSet.has(avsAddress)) {
+				continue
+			}
+
+			const operators = log.operatorRewards_operators || []
+			const amounts = log.operatorRewards_amounts || []
+
+			// Ensure operators and amounts arrays match in length
+			if (operators.length === 0 || amounts.length !== operators.length) {
+				continue
+			}
+
+			for (let i = 0; i < operators.length; i++) {
+				const operatorAddress = operators[i].toLowerCase()
+
+				if (!existingOperatorsSet.has(operatorAddress)) {
+					continue
+				}
+
+				const totalAmount = new prisma.Prisma.Decimal(amounts[i])
+				const multipliers = log.strategiesAndMultipliers_multipliers
+				const distributedAmounts = distributeAmount(totalAmount, multipliers)
+
+				for (const [index, strategy] of log.strategiesAndMultipliers_strategies.entries()) {
+					operatorDirectedRewardSubmissionList.push({
+						submissionNonce: log.submissionNonce,
+						operatorDirectedRewardsSubmissionHash: log.operatorDirectedRewardsSubmissionHash,
+						avsAddress,
+						operatorSetId: log.operatorSetId,
+						operatorAddress,
+						strategyAddress: strategy.toLowerCase(),
+						multiplier: new prisma.Prisma.Decimal(log.strategiesAndMultipliers_multipliers[index]),
+						token: log.operatorDirectedRewardsSubmission_token.toLowerCase(),
+						amount: distributedAmounts[index],
+						startTimestamp: log.operatorDirectedRewardsSubmission_startTimestamp,
+						duration: log.operatorDirectedRewardsSubmission_duration,
+						description: log.operatorDirectedRewardsSubmission_description,
+						createdAtBlock: log.blockNumber,
+						createdAt: log.blockTime
+					})
+				}
+			}
+		}
+	})
+
+	// Prepare db transaction object
+	const dbTransactions: any[] = []
+	if (operatorDirectedRewardSubmissionList.length > 0) {
+		dbTransactions.push(
+			prismaClient.operatorDirectedOperatorSetRewardsSubmission.createMany({
+				data: operatorDirectedRewardSubmissionList,
+				skipDuplicates: true
+			})
+		)
+	}
+
+	await bulkUpdateDbTransactions(
+		dbTransactions,
+		`[Data] Operator Directed Operator Set Rewards from: ${firstBlock} to: ${lastBlock} size: ${operatorDirectedRewardSubmissionList.length}`
+	)
+
+	// Storing last synced block
+	await saveLastSyncBlock(blockSyncKey, lastBlock)
+}

--- a/packages/seeder/src/seedOperatorSet.ts
+++ b/packages/seeder/src/seedOperatorSet.ts
@@ -75,6 +75,7 @@ export async function seedOperatorSet(toBlock?: bigint, fromBlock?: bigint) {
 					avsAddress,
 					operatorSetId: BigInt(log.operatorSetId),
 					strategies: [],
+					redistributionRecipient: '',
 					createdAtBlock: blockNumber,
 					updatedAtBlock: blockNumber,
 					createdAt,

--- a/packages/seeder/src/seedOperatorSetRedistributionAddress.ts
+++ b/packages/seeder/src/seedOperatorSetRedistributionAddress.ts
@@ -1,0 +1,73 @@
+import { getPrismaClient } from './utils/prismaClient'
+import {
+	bulkUpdateDbTransactions,
+	fetchLastSyncBlock,
+	loopThroughBlocks,
+	saveLastSyncBlock
+} from './utils/seeder'
+
+const blockSyncKey = 'lastSyncedBlock_redistributionAddress'
+const blockSyncKeyLogs = 'lastSyncedBlock_logs_redistributionAddress'
+
+export async function seedOperatorSetRedistributionAddress(toBlock?: bigint, fromBlock?: bigint) {
+	const prismaClient = getPrismaClient()
+
+	const operatorSet = await prismaClient.operatorSet.findMany({
+		select: {
+			avsAddress: true,
+			operatorSetId: true
+		}
+	})
+	const existingSets = new Set(
+		operatorSet.map((os) => `${os.avsAddress.toLowerCase()}-${os.operatorSetId}`)
+	)
+
+	const firstBlock = fromBlock ?? (await fetchLastSyncBlock(blockSyncKey))
+	const lastBlock = toBlock ?? (await fetchLastSyncBlock(blockSyncKeyLogs))
+	if (lastBlock - firstBlock <= 0n) {
+		console.log(`[In Sync] [Data] Redistribution Address from: ${firstBlock} to: ${lastBlock}`)
+		return
+	}
+
+	const redistributionRecipientUpdates = new Map<string, string>()
+	await loopThroughBlocks(
+		firstBlock,
+		lastBlock,
+		async (fromBlock, toBlock) => {
+			const logs = await prismaClient.eventLogs_RedistributionAddressSet.findMany({
+				where: { blockNumber: { gt: fromBlock, lte: toBlock } }
+			})
+
+			for (const log of logs) {
+				const key = `${log.avs.toLowerCase()}-${log.operatorSetId}`
+				if (existingSets.has(key))
+					redistributionRecipientUpdates.set(key, log.redistributionRecipient.toLowerCase())
+			}
+		},
+		10_000n
+	)
+
+	const dbTransactions: any[] = []
+	for (const [operatorSet, redistributionRecipient] of redistributionRecipientUpdates) {
+		const [avsAddress, operatorSetIdStr] = operatorSet.split('-')
+		const operatorSetId = BigInt(operatorSetIdStr)
+		dbTransactions.push(
+			prismaClient.operatorSet.update({
+				where: {
+					avsAddress_operatorSetId: {
+						avsAddress,
+						operatorSetId
+					}
+				},
+				data: { redistributionRecipient }
+			})
+		)
+	}
+
+	await bulkUpdateDbTransactions(
+		dbTransactions,
+		`[Data] Redistribution Address from: ${firstBlock} to: ${lastBlock} size: ${redistributionRecipientUpdates.size}`
+	)
+
+	await saveLastSyncBlock(blockSyncKey, lastBlock)
+}


### PR DESCRIPTION
### Changes in this PR

* Added **event log seeders** for the events `RedistributionAddressSet` and `OperatorDirectedOperatorSetRewardsSubmission`.
* Introduced a new table **`OperatorDirectedOperatorSetRewardsSubmission`** in the schema to track **Operator-Set Rewards**.
* Added a new column **`redistributionRecipient`** to the `OperatorSet` table, enabling tracking of whether an Operator-Set supports redistribution or burns slashed funds.

### Note
* These new seeders can be included in `index.ts` once we decide to start tracking them